### PR TITLE
Fix unit test crash when expected rows use SQL format

### DIFF
--- a/dbt/include/confluent/macros/materializations/tests/unit.sql
+++ b/dbt/include/confluent/macros/materializations/tests/unit.sql
@@ -31,7 +31,8 @@ it works fine anyway. #}
   {% endif %}
   {% set unit_test_sql = get_unit_test_sql(sql, expected_sql, expected_column_names_quoted) %}
 
-  {% call statement('main', fetch_result=True, limit=expected_rows | length) -%}
+  {% set fetch_limit = expected_rows | length if expected_rows | length > 0 else none %}
+  {% call statement('main', fetch_result=True, limit=fetch_limit) -%}
     {{ unit_test_sql }}
   {%- endcall %}
 


### PR DESCRIPTION
## Summary
- When unit tests use `format: sql` for expected rows, `expected_rows` is an empty list
- This caused `fetchmany(0)` which raises `size must be a positive integer, got 0`
- Fix: fall back to `fetchall` (limit=None) when `expected_rows` is empty

## Test plan
- [x] All 6 IoT pipeline unit tests pass (previously all crashed with this error)