### PR TITLE
Schema drift detection

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -59,7 +59,8 @@ blocks:
           commands:
             - |
               if [ -z "${CONFLUENT_FLINK_API_KEY:-}" ]; then
-                echo "CONFLUENT_FLINK_API_KEY not set, skipping tests"
+                echo "CONFLUENT_FLINK_API_KEY not set, skipping integration tests"
+                uv run pytest tests/unit --junitxml=test-results.xml
               else
                 uv run pytest --junitxml=test-results.xml
               fi

--- a/MATERIALIZATIONS.md
+++ b/MATERIALIZATIONS.md
@@ -16,12 +16,12 @@ When a table already exists and `--full-refresh` is not specified, the adapter p
 
 ### Configuration
 
-Control drift detection behavior with the `on_schema_change` config:
+Control drift detection behavior with the `on_schema_drift` config:
 
 ```sql
 {{ config(
     materialized='table',
-    on_schema_change='fail'  -- 'fail' (default) or 'ignore'
+    on_schema_drift='fail'  -- 'fail' (default) or 'ignore'
 ) }}
 ```
 
@@ -34,7 +34,7 @@ Control drift detection behavior with the `on_schema_change` config:
 -- Disable drift detection for a specific model
 {{ config(
     materialized='streaming_table',
-    on_schema_change='ignore'
+    on_schema_drift='ignore'
 ) }}
 select * from {{ ref('source') }}
 ```

--- a/MATERIALIZATIONS.md
+++ b/MATERIALIZATIONS.md
@@ -14,6 +14,8 @@
 
 When a table already exists and `--full-refresh` is not specified, the adapter performs drift detection before skipping creation.
 
+To determine the expected schema, the adapter creates a short-lived temporary table (named `__dbt_tmp_schema_check_<model>_<invocation_id>`) and queries `INFORMATION_SCHEMA.COLUMNS` for its column names and data types. For `table` and `streaming_table`, this temp table is created from the model's SELECT query; for `streaming_source`, it is created from the model's column definitions (without the connector). The temp table is dropped immediately after the schema is read.
+
 ### Configuration
 
 Control drift detection behavior with the `on_schema_drift` config:

--- a/MATERIALIZATIONS.md
+++ b/MATERIALIZATIONS.md
@@ -12,7 +12,32 @@
 
 ## Schema Drift Detection
 
-When a table already exists and `--full-refresh` is not specified, the adapter performs drift detection before skipping creation:
+When a table already exists and `--full-refresh` is not specified, the adapter performs drift detection before skipping creation.
+
+### Configuration
+
+Control drift detection behavior with the `on_schema_change` config:
+
+```sql
+{{ config(
+    materialized='table',
+    on_schema_change='fail'  -- 'fail' (default) or 'ignore'
+) }}
+```
+
+**Options**:
+- `fail` (default) - Raise an error if schema drift is detected
+- `ignore` - Skip drift detection entirely; always skip if the table exists
+
+**Example**:
+```sql
+-- Disable drift detection for a specific model
+{{ config(
+    materialized='streaming_table',
+    on_schema_change='ignore'
+) }}
+select * from {{ ref('source') }}
+```
 
 ### Column Drift
 - **table, streaming_table**: Compares existing column names and data types with expected columns from the SELECT query. Raises an error if columns are added, removed, renamed, or if data types change. Column reordering is allowed (order doesn't matter for Kafka-backed tables).

--- a/MATERIALIZATIONS.md
+++ b/MATERIALIZATIONS.md
@@ -4,16 +4,16 @@
 
 | Materialization | Description |
 |---|---|
-| `table` | Creates a table via `CREATE TABLE ... AS SELECT` (CTAS). Runs in snapshot mode — the query executes once and completes. Requires `--full-refresh` to replace an existing table. |
+| `table` | Creates a table via `CREATE TABLE ... AS SELECT` (CTAS). Runs in snapshot mode — the query executes once and completes. If the table already exists, skips creation (use `--full-refresh` to drop and recreate). |
 | `view` | Drop-and-recreate view. |
-| `materialized_view` | Creates a Flink table via CTAS that is continuously updated by Flink. No manual refresh needed. Note: despite the dbt name, this creates a Flink table with a continuous query, not a traditional database materialized view. |
-| `streaming_table` | Creates a table then runs a separate continuous `INSERT INTO ... SELECT` statement. This two-statement approach is currently the preferred way to build streaming pipelines (until Flink's materialized table feature reaches GA). Supports table options via `config(with={...})`. Requires `--full-refresh` to replace an existing table. |
-| `streaming_source` | Creates a connector-backed source table (e.g., Datagen). Requires `config(connector='...')`. The model SQL defines the column definitions. Supports additional connector options via `config(with={...})`. Requires `--full-refresh` to replace an existing table. See the [Confluent connector catalog](https://docs.confluent.io/cloud/current/connectors/index.html) and [Flink CREATE TABLE documentation](https://docs.confluent.io/cloud/current/flink/reference/statements/create-table.html) for available connectors and options. |
+| `streaming_table` | Creates a table then runs a separate continuous `INSERT INTO ... SELECT` statement. This two-statement approach is currently the preferred way to build streaming pipelines (until Flink's materialized table feature reaches GA). Supports table options via `config(with={...})`. If the table already exists, skips creation (use `--full-refresh` to drop and recreate). |
+| `streaming_source` | Creates a connector-backed source table (e.g., Datagen). Requires `config(connector='...')`. The model SQL defines the column definitions. Supports additional connector options via `config(with={...})`. If the table already exists, skips creation (use `--full-refresh` to drop and recreate). See the [Confluent connector catalog](https://docs.confluent.io/cloud/current/connectors/index.html) and [Flink CREATE TABLE documentation](https://docs.confluent.io/cloud/current/flink/reference/statements/create-table.html) for available connectors and options. |
 | `ephemeral` | Standard dbt CTE-based query fragment, not materialized in Flink. |
 
 ## Not Supported
 
 | Materialization | Reason |
 |---|---|
+| `materialized_view` | Use `table` instead. In Confluent Flink, materialized views are implemented as CTAS tables that are continuously updated by Flink. |
 | `incremental` | dbt's batch-incremental semantics does not map to Flink's continuous processing model. Use `streaming_table` instead. |
 | `snapshot` | Flink SQL lacks the batch operations (MERGE, UPDATE) required by dbt snapshots. |

--- a/MATERIALIZATIONS.md
+++ b/MATERIALIZATIONS.md
@@ -61,6 +61,23 @@ config(with={})
 
 If you need to change or remove WITH options, use `--full-refresh` to drop and recreate the table.
 
+### Query Logic Changes
+
+Schema drift detection only inspects **column names, data types, and WITH options** — it does not detect changes to the query logic itself. If you modify how a column is computed without changing its name or type, the adapter will see no drift and skip the model.
+
+**Example of undetected change**:
+```sql
+-- Initial model
+select order_id, round(price, 2) as price from {{ ref('source') }}
+
+-- Changed to (different rounding)
+select order_id, round(price, 4) as price from {{ ref('source') }}
+
+-- Result: Column name and type are unchanged, so dbt will skip (no error)
+```
+
+This is an inherent limitation — `INFORMATION_SCHEMA` only stores schema metadata, not the query that produced the table. If you change query logic, use `--full-refresh` to recreate the table.
+
 ### When Drift is Detected
 If drift is detected, the run will fail with a compilation error. Use `--full-refresh` to drop and recreate the table with the new schema or options.
 

--- a/MATERIALIZATIONS.md
+++ b/MATERIALIZATIONS.md
@@ -4,24 +4,40 @@
 
 | Materialization | Description |
 |---|---|
-| `table` | Creates a table via `CREATE TABLE ... AS SELECT` (CTAS). Runs in snapshot mode — the query executes once and completes. If the table already exists, checks for schema drift and skips creation (use `--full-refresh` to drop and recreate). |
+| `table` | Creates a table via `CREATE TABLE ... AS SELECT` (CTAS). Runs in snapshot mode — the query executes once and completes. If the table already exists, checks for schema drift (column names, data types, WITH options) and skips creation (use `--full-refresh` to drop and recreate). |
 | `view` | Drop-and-recreate view. |
-| `streaming_table` | Creates a table then runs a separate continuous `INSERT INTO ... SELECT` statement. This two-statement approach is currently the preferred way to build streaming pipelines (until Flink's materialized table feature reaches GA). Supports table options via `config(with={...})`. If the table already exists, checks for schema drift and skips creation (use `--full-refresh` to drop and recreate). |
-| `streaming_source` | Creates a connector-backed source table (e.g., Datagen). Requires `config(connector='...')`. The model SQL defines the column definitions. Supports additional connector options via `config(with={...})`. If the table already exists, checks for options drift and skips creation (use `--full-refresh` to drop and recreate). See the [Confluent connector catalog](https://docs.confluent.io/cloud/current/connectors/index.html) and [Flink CREATE TABLE documentation](https://docs.confluent.io/cloud/current/flink/reference/statements/create-table.html) for available connectors and options. |
+| `streaming_table` | Creates a table then runs a separate continuous `INSERT INTO ... SELECT` statement. This two-statement approach is currently the preferred way to build streaming pipelines (until Flink's materialized table feature reaches GA). Supports table options via `config(with={...})`. If the table already exists, checks for schema drift (column names, data types, WITH options) and skips creation (use `--full-refresh` to drop and recreate). |
+| `streaming_source` | Creates a connector-backed source table (e.g., Datagen). Requires `config(connector='...')`. The model SQL defines the column definitions. Supports additional connector options via `config(with={...})`. If the table already exists, checks for schema drift (column names, data types, WITH options) and skips creation (use `--full-refresh` to drop and recreate). See the [Confluent connector catalog](https://docs.confluent.io/cloud/current/connectors/index.html) and [Flink CREATE TABLE documentation](https://docs.confluent.io/cloud/current/flink/reference/statements/create-table.html) for available connectors and options. |
 | `ephemeral` | Standard dbt CTE-based query fragment, not materialized in Flink. |
 
 ## Schema Drift Detection
 
 When a table already exists and `--full-refresh` is not specified, the adapter performs drift detection before skipping creation:
 
-- **Column drift** (table, streaming_table): Compares existing column names with expected columns from the SELECT query. Raises an error if columns are added, removed, or renamed. Column reordering is allowed.
-- **Options drift** (all table types): Compares existing `WITH` options against the model's `config(with={...})`. Raises an error if any configured option has changed.
+### Column Drift
+- **table, streaming_table**: Compares existing column names and data types with expected columns from the SELECT query. Raises an error if columns are added, removed, renamed, or if data types change. Column reordering is allowed (order doesn't matter for Kafka-backed tables).
+- **streaming_source**: Compares existing column names and data types with the column definitions in the model SQL. Raises an error if columns are added, removed, renamed, or if data types change. Uses a temporary table to infer schema from SQL column definitions.
 
-**Limitations:**
-- Column data types are not checked — only names
-- For `streaming_source`, column drift is not detected (only `WITH` options are checked)
+### WITH Options Drift
+Compares existing `WITH` options against the model's `config(with={...})`. Raises an error if any configured option value has changed.
 
-If drift is detected, use `--full-refresh` to drop and recreate the table.
+**Important limitation**: The adapter only verifies that user-specified options exist with the correct values. It does **not** detect when options are removed from the config, because connectors may add default options automatically (e.g., `fields.*.expression` from the faker connector), and we cannot distinguish between user-specified and auto-generated options.
+
+**Example of undetected drift**:
+```sql
+-- Initial config
+config(with={'changelog.mode': 'upsert'})
+
+-- Changed to (option removed)
+config(with={})
+
+-- Result: The table still has changelog.mode=upsert, but dbt will skip (no error)
+```
+
+If you need to change or remove WITH options, use `--full-refresh` to drop and recreate the table.
+
+### When Drift is Detected
+If drift is detected, the run will fail with a compilation error. Use `--full-refresh` to drop and recreate the table with the new schema or options.
 
 ## Not Supported
 

--- a/MATERIALIZATIONS.md
+++ b/MATERIALIZATIONS.md
@@ -4,11 +4,24 @@
 
 | Materialization | Description |
 |---|---|
-| `table` | Creates a table via `CREATE TABLE ... AS SELECT` (CTAS). Runs in snapshot mode — the query executes once and completes. If the table already exists, skips creation (use `--full-refresh` to drop and recreate). |
+| `table` | Creates a table via `CREATE TABLE ... AS SELECT` (CTAS). Runs in snapshot mode — the query executes once and completes. If the table already exists, checks for schema drift and skips creation (use `--full-refresh` to drop and recreate). |
 | `view` | Drop-and-recreate view. |
-| `streaming_table` | Creates a table then runs a separate continuous `INSERT INTO ... SELECT` statement. This two-statement approach is currently the preferred way to build streaming pipelines (until Flink's materialized table feature reaches GA). Supports table options via `config(with={...})`. If the table already exists, skips creation (use `--full-refresh` to drop and recreate). |
-| `streaming_source` | Creates a connector-backed source table (e.g., Datagen). Requires `config(connector='...')`. The model SQL defines the column definitions. Supports additional connector options via `config(with={...})`. If the table already exists, skips creation (use `--full-refresh` to drop and recreate). See the [Confluent connector catalog](https://docs.confluent.io/cloud/current/connectors/index.html) and [Flink CREATE TABLE documentation](https://docs.confluent.io/cloud/current/flink/reference/statements/create-table.html) for available connectors and options. |
+| `streaming_table` | Creates a table then runs a separate continuous `INSERT INTO ... SELECT` statement. This two-statement approach is currently the preferred way to build streaming pipelines (until Flink's materialized table feature reaches GA). Supports table options via `config(with={...})`. If the table already exists, checks for schema drift and skips creation (use `--full-refresh` to drop and recreate). |
+| `streaming_source` | Creates a connector-backed source table (e.g., Datagen). Requires `config(connector='...')`. The model SQL defines the column definitions. Supports additional connector options via `config(with={...})`. If the table already exists, checks for options drift and skips creation (use `--full-refresh` to drop and recreate). See the [Confluent connector catalog](https://docs.confluent.io/cloud/current/connectors/index.html) and [Flink CREATE TABLE documentation](https://docs.confluent.io/cloud/current/flink/reference/statements/create-table.html) for available connectors and options. |
 | `ephemeral` | Standard dbt CTE-based query fragment, not materialized in Flink. |
+
+## Schema Drift Detection
+
+When a table already exists and `--full-refresh` is not specified, the adapter performs drift detection before skipping creation:
+
+- **Column drift** (table, streaming_table): Compares existing column names with expected columns from the SELECT query. Raises an error if columns are added, removed, or renamed. Column reordering is allowed.
+- **Options drift** (all table types): Compares existing `WITH` options against the model's `config(with={...})`. Raises an error if any configured option has changed.
+
+**Limitations:**
+- Column data types are not checked — only names
+- For `streaming_source`, column drift is not detected (only `WITH` options are checked)
+
+If drift is detected, use `--full-refresh` to drop and recreate the table.
 
 ## Not Supported
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ See [Materializations](MATERIALIZATIONS.md) for the full list and details.
 - **No transactions**: Flink SQL is non-transactional.
 - **No snapshots**: Flink SQL lacks the batch operations (MERGE, UPDATE) required by dbt snapshots.
 - **No incremental**: dbt's batch-incremental semantics does not map to Flink's continuous processing model. Use `streaming_table` instead.
-- **Drift detection for WITH options**: Schema drift detection only verifies that user-specified `WITH` options exist with correct values. It cannot detect when options are removed from the config (because connectors may add default options that cannot be distinguished from user-specified ones). Use `--full-refresh` to change or remove WITH options. See [Materializations](MATERIALIZATIONS.md#schema-drift-detection) for details.
+- **Drift detection for WITH options**: Schema drift detection only verifies that user-specified `WITH` options exist with correct values. It cannot detect when options are removed from the config (because connectors may add default options that cannot be distinguished from user-specified ones). Use `--full-refresh` to change or remove WITH options. Drift detection can be disabled per-model with `config(on_schema_change='ignore')`. See [Materializations](MATERIALIZATIONS.md#schema-drift-detection) for details.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ See [Materializations](MATERIALIZATIONS.md) for the full list and details.
 - **No transactions**: Flink SQL is non-transactional.
 - **No snapshots**: Flink SQL lacks the batch operations (MERGE, UPDATE) required by dbt snapshots.
 - **No incremental**: dbt's batch-incremental semantics does not map to Flink's continuous processing model. Use `streaming_table` instead.
-- **Drift detection for WITH options**: Schema drift detection only verifies that user-specified `WITH` options exist with correct values. It cannot detect when options are removed from the config (because connectors may add default options that cannot be distinguished from user-specified ones). Use `--full-refresh` to change or remove WITH options. Drift detection can be disabled per-model with `config(on_schema_change='ignore')`. See [Materializations](MATERIALIZATIONS.md#schema-drift-detection) for details.
+- **Drift detection for WITH options**: Schema drift detection only verifies that user-specified `WITH` options exist with correct values. It cannot detect when options are removed from the config (because connectors may add default options that cannot be distinguished from user-specified ones). Use `--full-refresh` to change or remove WITH options. Drift detection can be disabled per-model with `config(on_schema_drift='ignore')`. See [Materializations](MATERIALIZATIONS.md#schema-drift-detection) for details.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ See [Materializations](MATERIALIZATIONS.md) for the full list and details.
 - **No transactions**: Flink SQL is non-transactional.
 - **No snapshots**: Flink SQL lacks the batch operations (MERGE, UPDATE) required by dbt snapshots.
 - **No incremental**: dbt's batch-incremental semantics does not map to Flink's continuous processing model. Use `streaming_table` instead.
+- **Drift detection for WITH options**: Schema drift detection only verifies that user-specified `WITH` options exist with correct values. It cannot detect when options are removed from the config (because connectors may add default options that cannot be distinguished from user-specified ones). Use `--full-refresh` to change or remove WITH options. See [Materializations](MATERIALIZATIONS.md#schema-drift-detection) for details.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Build, test, and manage streaming data transformations on Confluent Cloud using 
 Features:
 - Standard dbt materializations (table, view, ephemeral) adapted for Flink SQL
 - Streaming-native materializations (`streaming_table`, `streaming_source`) for continuous data pipelines
-- Materialized views powered by Flink's continuous query execution
 - Integration with Confluent Cloud connectors (e.g., Datagen/Faker) via `streaming_source`
 
 See [Materializations](MATERIALIZATIONS.md) for the full list and details.

--- a/dbt/adapters/confluent/__version__.py
+++ b/dbt/adapters/confluent/__version__.py
@@ -1,1 +1,1 @@
-version = "0.1.0"
+version = "0.2.0"

--- a/dbt/adapters/confluent/impl.py
+++ b/dbt/adapters/confluent/impl.py
@@ -292,6 +292,11 @@ class ConfluentAdapter(SQLAdapter):
         return {"ctes": ctes, "main_sql": main_sql}
 
     @available
+    def generate_schema_check_temp_name(self, identifier: str, invocation_id: str) -> str:
+        """Generate a unique temporary table name for schema drift checks."""
+        return "__dbt_tmp_schema_check_" + identifier + "_" + invocation_id.replace("-", "")
+
+    @available
     def check_schema_drift(
         self,
         relation_name: str,

--- a/dbt/adapters/confluent/impl.py
+++ b/dbt/adapters/confluent/impl.py
@@ -291,84 +291,20 @@ class ConfluentAdapter(SQLAdapter):
 
         return {"ctes": ctes, "main_sql": main_sql}
 
-    # Flink SQL type aliases — map shorthand names to what INFORMATION_SCHEMA
-    # reports in FULL_DATA_TYPE.  Order matters: longer prefixes first so that
-    # e.g. "DOUBLE PRECISION" is matched before "DOUBLE".
-    # Reference: https://docs.confluent.io/cloud/current/flink/reference/datatypes.html
-    _TYPE_ALIASES: list[tuple[str, str]] = [
-        ("STRING", "VARCHAR(2147483647)"),      # datatypes.html#varchar-string
-        ("BYTES", "VARBINARY(2147483647)"),      # datatypes.html#bytes-varbinary
-        ("INTEGER", "INT"),                      # datatypes.html#int
-        ("DOUBLE PRECISION", "DOUBLE"),          # datatypes.html#double
-    ]
-
     @staticmethod
     def _normalize_type(type_str: str) -> str:
         """Normalize a SQL type string for comparison.
 
-        Uppercases, collapses whitespace, normalizes bracket/comma spacing,
-        and resolves Flink SQL type aliases (e.g. STRING → VARCHAR(2147483647))
-        to match what INFORMATION_SCHEMA.FULL_DATA_TYPE reports.
+        Uppercases, collapses whitespace, and normalizes bracket/comma spacing
+        so that e.g. 'DECIMAL(10,2)' and 'DECIMAL(10, 2)' compare equal.
         """
         s = " ".join(type_str.upper().split())
-        # Normalize parenthesized and angle-bracket parameters.
         s = re.sub(r"\s*\(\s*", "(", s)
         s = re.sub(r"\s*\)", ")", s)
         s = re.sub(r"\s*<\s*", "<", s)
         s = re.sub(r"\s*>", ">", s)
         s = re.sub(r"\s*,\s*", ", ", s)
-        # Resolve type aliases to canonical INFORMATION_SCHEMA form.
-        for alias, canonical in ConfluentAdapter._TYPE_ALIASES:
-            if s == alias:
-                s = canonical
-                break
         return s
-
-    @available
-    def parse_column_definitions(self, sql: str) -> list[dict[str, str]]:
-        """Parse streaming_source column definitions from raw SQL.
-
-        Extracts column name and data type from backtick-quoted column
-        definitions.  Skips WATERMARK and PRIMARY KEY clauses.
-
-        Returns list of dicts: [{'column_name': ..., 'data_type': ...}]
-        """
-        # Split by commas at bracket-depth 0 to handle types like
-        # DECIMAL(10, 2) and MAP<STRING, INT>.
-        parts: list[str] = []
-        depth = 0
-        current: list[str] = []
-        for ch in sql:
-            if ch in "(<":
-                depth += 1
-                current.append(ch)
-            elif ch in ")>":
-                depth -= 1
-                current.append(ch)
-            elif ch == "," and depth == 0:
-                parts.append("".join(current).strip())
-                current = []
-            else:
-                current.append(ch)
-        tail = "".join(current).strip()
-        if tail:
-            parts.append(tail)
-
-        col_re = re.compile(r"^`([^`]+)`\s+(.+)$", re.IGNORECASE | re.DOTALL)
-        columns: list[dict[str, str]] = []
-        for part in parts:
-            upper = part.lstrip().upper()
-            if upper.startswith("WATERMARK") or upper.startswith("PRIMARY"):
-                continue
-            m = col_re.match(part)
-            if m:
-                columns.append(
-                    {
-                        "column_name": m.group(1),
-                        "data_type": self._normalize_type(m.group(2)),
-                    }
-                )
-        return columns
 
     @available
     def check_schema_drift(

--- a/dbt/adapters/confluent/impl.py
+++ b/dbt/adapters/confluent/impl.py
@@ -291,21 +291,6 @@ class ConfluentAdapter(SQLAdapter):
 
         return {"ctes": ctes, "main_sql": main_sql}
 
-    @staticmethod
-    def _normalize_type(type_str: str) -> str:
-        """Normalize a SQL type string for comparison.
-
-        Uppercases, collapses whitespace, and normalizes bracket/comma spacing
-        so that e.g. 'DECIMAL(10,2)' and 'DECIMAL(10, 2)' compare equal.
-        """
-        s = " ".join(type_str.upper().split())
-        s = re.sub(r"\s*\(\s*", "(", s)
-        s = re.sub(r"\s*\)", ")", s)
-        s = re.sub(r"\s*<\s*", "<", s)
-        s = re.sub(r"\s*>", ">", s)
-        s = re.sub(r"\s*,\s*", ", ", s)
-        return s
-
     @available
     def check_schema_drift(
         self,
@@ -318,21 +303,15 @@ class ConfluentAdapter(SQLAdapter):
         """Compare existing vs expected schema and raise CompilationError on drift.
 
         existing_columns: agate.Table from INFORMATION_SCHEMA query
-        expected_columns: agate.Table (from CTAS temp table) or list[dict] (from parse_column_definitions)
+        expected_columns: agate.Table from INFORMATION_SCHEMA query (via temp table)
         expected_with: config(with={...}) dict
         existing_options: dict from INFORMATION_SCHEMA.TABLE_OPTIONS
         """
-
-        def _col_map(columns) -> dict[str, str]:
-            result = {}
-            for col in columns:
-                name = col["column_name"].lower()
-                dtype = self._normalize_type(col["data_type"])
-                result[name] = dtype
-            return result
-
-        existing_map = _col_map(existing_columns)
-        expected_map = _col_map(expected_columns)
+        # No type normalization: both existing and expected columns come from
+        # INFORMATION_SCHEMA.COLUMNS queries, so types are already in Flink's
+        # canonical form.
+        existing_map = {col["column_name"]: col["data_type"] for col in existing_columns}
+        expected_map = {col["column_name"]: col["data_type"] for col in expected_columns}
 
         existing_names = sorted(existing_map)
         expected_names = sorted(expected_map)
@@ -356,11 +335,11 @@ class ConfluentAdapter(SQLAdapter):
 
         for key, value in expected_with.items():
             existing_value = existing_options.get(key)
-            if existing_value != value:
+            if existing_value != str(value):
                 raise CompilationError(
                     f"Table options drift detected for '{relation_name}'.\n"
                     f"Option '{key}': "
-                    f"existing='{existing_value or '<not set>'}', expected='{value}'.\n"
+                    f"existing='{existing_value or '<not set>'}', expected='{str(value)}'.\n"
                     f"Use --full-refresh to recreate the table."
                 )
 

--- a/dbt/adapters/confluent/impl.py
+++ b/dbt/adapters/confluent/impl.py
@@ -291,6 +291,143 @@ class ConfluentAdapter(SQLAdapter):
 
         return {"ctes": ctes, "main_sql": main_sql}
 
+    # Flink SQL type aliases — map shorthand names to what INFORMATION_SCHEMA
+    # reports in FULL_DATA_TYPE.  Order matters: longer prefixes first so that
+    # e.g. "DOUBLE PRECISION" is matched before "DOUBLE".
+    # Reference: https://docs.confluent.io/cloud/current/flink/reference/datatypes.html
+    _TYPE_ALIASES: list[tuple[str, str]] = [
+        ("STRING", "VARCHAR(2147483647)"),      # datatypes.html#varchar-string
+        ("BYTES", "VARBINARY(2147483647)"),      # datatypes.html#bytes-varbinary
+        ("INTEGER", "INT"),                      # datatypes.html#int
+        ("DOUBLE PRECISION", "DOUBLE"),          # datatypes.html#double
+    ]
+
+    @staticmethod
+    def _normalize_type(type_str: str) -> str:
+        """Normalize a SQL type string for comparison.
+
+        Uppercases, collapses whitespace, normalizes bracket/comma spacing,
+        and resolves Flink SQL type aliases (e.g. STRING → VARCHAR(2147483647))
+        to match what INFORMATION_SCHEMA.FULL_DATA_TYPE reports.
+        """
+        s = " ".join(type_str.upper().split())
+        # Normalize parenthesized and angle-bracket parameters.
+        s = re.sub(r"\s*\(\s*", "(", s)
+        s = re.sub(r"\s*\)", ")", s)
+        s = re.sub(r"\s*<\s*", "<", s)
+        s = re.sub(r"\s*>", ">", s)
+        s = re.sub(r"\s*,\s*", ", ", s)
+        # Resolve type aliases to canonical INFORMATION_SCHEMA form.
+        for alias, canonical in ConfluentAdapter._TYPE_ALIASES:
+            if s == alias:
+                s = canonical
+                break
+        return s
+
+    @available
+    def parse_column_definitions(self, sql: str) -> list[dict[str, str]]:
+        """Parse streaming_source column definitions from raw SQL.
+
+        Extracts column name and data type from backtick-quoted column
+        definitions.  Skips WATERMARK and PRIMARY KEY clauses.
+
+        Returns list of dicts: [{'column_name': ..., 'data_type': ...}]
+        """
+        # Split by commas at bracket-depth 0 to handle types like
+        # DECIMAL(10, 2) and MAP<STRING, INT>.
+        parts: list[str] = []
+        depth = 0
+        current: list[str] = []
+        for ch in sql:
+            if ch in "(<":
+                depth += 1
+                current.append(ch)
+            elif ch in ")>":
+                depth -= 1
+                current.append(ch)
+            elif ch == "," and depth == 0:
+                parts.append("".join(current).strip())
+                current = []
+            else:
+                current.append(ch)
+        tail = "".join(current).strip()
+        if tail:
+            parts.append(tail)
+
+        col_re = re.compile(r"^`([^`]+)`\s+(.+)$", re.IGNORECASE | re.DOTALL)
+        columns: list[dict[str, str]] = []
+        for part in parts:
+            upper = part.lstrip().upper()
+            if upper.startswith("WATERMARK") or upper.startswith("PRIMARY"):
+                continue
+            m = col_re.match(part)
+            if m:
+                columns.append(
+                    {
+                        "column_name": m.group(1),
+                        "data_type": self._normalize_type(m.group(2)),
+                    }
+                )
+        return columns
+
+    @available
+    def check_schema_drift(
+        self,
+        relation_name: str,
+        existing_columns,
+        expected_columns,
+        expected_with: dict[str, str],
+        existing_options: dict[str, str],
+    ) -> None:
+        """Compare existing vs expected schema and raise CompilationError on drift.
+
+        existing_columns: agate.Table from INFORMATION_SCHEMA query
+        expected_columns: agate.Table (from CTAS temp table) or list[dict] (from parse_column_definitions)
+        expected_with: config(with={...}) dict
+        existing_options: dict from INFORMATION_SCHEMA.TABLE_OPTIONS
+        """
+
+        def _col_map(columns) -> dict[str, str]:
+            result = {}
+            for col in columns:
+                name = col["column_name"].lower()
+                dtype = self._normalize_type(col["data_type"])
+                result[name] = dtype
+            return result
+
+        existing_map = _col_map(existing_columns)
+        expected_map = _col_map(expected_columns)
+
+        existing_names = sorted(existing_map)
+        expected_names = sorted(expected_map)
+
+        if existing_names != expected_names:
+            raise CompilationError(
+                f"Schema drift detected for '{relation_name}'.\n"
+                f"Existing columns: {existing_names}\n"
+                f"Expected columns: {expected_names}\n"
+                f"Use --full-refresh to recreate the table."
+            )
+
+        for col_name in expected_map:
+            if existing_map[col_name] != expected_map[col_name]:
+                raise CompilationError(
+                    f"Schema drift detected for '{relation_name}'.\n"
+                    f"Column '{col_name}' type mismatch: "
+                    f"existing='{existing_map[col_name]}', expected='{expected_map[col_name]}'.\n"
+                    f"Use --full-refresh to recreate the table."
+                )
+
+        for key, value in expected_with.items():
+            existing_value = existing_options.get(key)
+            if existing_value != value:
+                raise CompilationError(
+                    f"Table options drift detected for '{relation_name}'.\n"
+                    f"Option '{key}': "
+                    f"existing='{existing_value or '<not set>'}', expected='{value}'.\n"
+                    f"Use --full-refresh to recreate the table."
+                )
+
     def run_sql_for_tests(self, sql, fetch, conn):
         cursor = conn.handle.cursor(mode=conn.credentials.execution_mode)
         try:

--- a/dbt/include/confluent/macros/adapters/columns.sql
+++ b/dbt/include/confluent/macros/adapters/columns.sql
@@ -17,3 +17,44 @@
   {% set table = load_result('get_columns_in_relation').table %}
   {{ return(sql_convert_columns_in_relation(table)) }}
 {%- endmacro %}
+
+
+{% macro validate_column_data_types(columns) %}
+  {#-- Validate that data_type fields don't contain constraint keywords.
+       Constraints should be in the 'constraints' section instead. --#}
+  {% set constraint_keywords = ['NOT NULL', 'VIRTUAL', 'METADATA', 'NOT ENFORCED'] %}
+
+  {% for i in columns %}
+    {% set col = columns[i] %}
+    {% set data_type = col.get('data_type', '') | upper %}
+
+    {% for keyword in constraint_keywords %}
+      {% if keyword in data_type %}
+        {% set clean_type = col['data_type'] | replace(keyword, '') | replace(keyword | lower, '') | trim %}
+        {% set msg %}
+Column '{{ col['name'] }}' has constraint keywords in the data_type field.
+
+Found:
+  - name: {{ col['name'] }}
+    data_type: {{ col['data_type'] }}
+
+With this adapter, constraints must be specified separately in the 'constraints' section:
+  - name: {{ col['name'] }}
+    data_type: {{ clean_type }}
+    constraints:
+      - type: not_null  # or primary_key, etc.
+        {% endset %}
+        {{ exceptions.raise_compiler_error(msg) }}
+      {% endif %}
+    {% endfor %}
+  {% endfor %}
+{% endmacro %}
+
+
+{% macro confluent__get_empty_schema_sql(columns) %}
+  {#-- Validate column data types before proceeding --#}
+  {{ validate_column_data_types(columns) }}
+
+  {#-- Call the default implementation --#}
+  {{ return(dbt.default__get_empty_schema_sql(columns)) }}
+{% endmacro %}

--- a/dbt/include/confluent/macros/adapters/columns.sql
+++ b/dbt/include/confluent/macros/adapters/columns.sql
@@ -21,8 +21,9 @@
 
 {% macro validate_column_data_types(columns) %}
   {#-- Validate that data_type fields don't contain constraint keywords.
+       These keywords would cause SQL errors in CAST expressions.
        Constraints should be in the 'constraints' section instead. --#}
-  {% set constraint_keywords = ['NOT NULL', 'VIRTUAL', 'METADATA', 'NOT ENFORCED'] %}
+  {% set constraint_keywords = ['NOT NULL', 'VIRTUAL', 'METADATA'] %}
 
   {% for i in columns %}
     {% set col = columns[i] %}
@@ -30,19 +31,15 @@
 
     {% for keyword in constraint_keywords %}
       {% if keyword in data_type %}
-        {% set clean_type = col['data_type'] | replace(keyword, '') | replace(keyword | lower, '') | trim %}
         {% set msg %}
-Column '{{ col['name'] }}' has constraint keywords in the data_type field.
+Column '{{ col['name'] }}' has constraint keyword in the data_type field.
 
 Found:
   - name: {{ col['name'] }}
     data_type: {{ col['data_type'] }}
 
-With this adapter, constraints must be specified separately in the 'constraints' section:
-  - name: {{ col['name'] }}
-    data_type: {{ clean_type }}
-    constraints:
-      - type: not_null  # or primary_key, etc.
+Constraint keywords like '{{ keyword }}' cannot appear in data type definitions.
+Use the 'constraints' section instead to specify column constraints.
         {% endset %}
         {{ exceptions.raise_compiler_error(msg) }}
       {% endif %}
@@ -52,9 +49,8 @@ With this adapter, constraints must be specified separately in the 'constraints'
 
 
 {% macro confluent__get_empty_schema_sql(columns) %}
-  {#-- Validate column data types before proceeding --#}
+  {#-- Validate column data types before generating SQL --#}
   {{ validate_column_data_types(columns) }}
-
-  {#-- Call the default implementation --#}
-  {{ return(dbt.default__get_empty_schema_sql(columns)) }}
+  {#-- Delegate to default implementation --#}
+  {{ return(default__get_empty_schema_sql(columns)) }}
 {% endmacro %}

--- a/dbt/include/confluent/macros/materializations/models/helpers.sql
+++ b/dbt/include/confluent/macros/materializations/models/helpers.sql
@@ -129,7 +129,10 @@
 
   {# Create temp table from the query #}
   {% call statement('create_temp_table') %}
-    CREATE TABLE {{ temp_relation }} AS {{ model_sql }} WHERE FALSE
+    CREATE TABLE {{ temp_relation }} AS
+    SELECT * FROM (
+      {{ model_sql }}
+    ) WHERE FALSE
   {% endcall %}
 
   {# Query INFORMATION_SCHEMA for column names and types #}

--- a/dbt/include/confluent/macros/materializations/models/helpers.sql
+++ b/dbt/include/confluent/macros/materializations/models/helpers.sql
@@ -1,7 +1,7 @@
 {% macro skip_or_drop_existing(existing_relation, target_relation, has_select_query=true) %}
   {# If the relation already exists, either drop it (on --full-refresh) or skip.
      Returns true if the caller should skip (relation exists and no full refresh).
-     Before skipping, checks for schema drift according to on_schema_change config.
+     Before skipping, checks for schema drift according to on_schema_drift config.
      has_select_query: true if the model SQL is a SELECT (table, streaming_table),
                        false if it's column definitions (streaming_source). #}
   {% if existing_relation %}
@@ -9,14 +9,14 @@
       {{ drop_relation_if_exists(existing_relation) }}
       {{ return(false) }}
     {% else %}
-      {% set on_schema_change = config.get('on_schema_change', 'fail') %}
-      {% if on_schema_change == 'ignore' %}
-        {{ log("Relation " ~ existing_relation ~ " already exists. Skipping without drift check (on_schema_change='ignore').", info=True) }}
-      {% elif on_schema_change == 'fail' %}
+      {% set on_schema_drift = config.get('on_schema_drift', 'fail') %}
+      {% if on_schema_drift == 'ignore' %}
+        {{ log("Relation " ~ existing_relation ~ " already exists. Skipping without drift check (on_schema_drift='ignore').", info=True) }}
+      {% elif on_schema_drift == 'fail' %}
         {{ check_for_schema_drift(existing_relation, has_select_query) }}
         {{ log("Relation " ~ existing_relation ~ " already exists. Skipping. Use --full-refresh to recreate.", info=True) }}
       {% else %}
-        {% set msg = "Invalid value for on_schema_change ('%s'). Expected 'ignore' or 'fail'." % on_schema_change %}
+        {% set msg = "Invalid value for on_schema_drift ('%s'). Expected 'ignore' or 'fail'." % on_schema_drift %}
         {% do exceptions.raise_compiler_error(msg) %}
       {% endif %}
       {{ return(true) }}
@@ -127,13 +127,18 @@
      Returns a list of dicts with column_name and data_type. #}
 
   {# Create a unique temp table name #}
-  {% set temp_table_name = '__dbt_tmp_schema_check_' ~ (modules.uuid.uuid4().hex) %}
+  {% set temp_table_name = '__dbt_tmp_schema_check_' ~ this.identifier %}
   {% set temp_relation = adapter.Relation.create(
     database=this.database,
     schema=this.schema,
     identifier=temp_table_name,
     type='table'
   ) %}
+
+  {# Drop any leftover temp table from a previous failed run #}
+  {% call statement('drop_temp_table_pre') %}
+    DROP TABLE IF EXISTS {{ temp_relation }}
+  {% endcall %}
 
   {# Create temp table from the query #}
   {% call statement('create_temp_table') %}
@@ -162,13 +167,18 @@
      Returns a list of dicts with column_name and data_type. #}
 
   {# Create a unique temp table name #}
-  {% set temp_table_name = '__dbt_tmp_schema_check_' ~ (modules.uuid.uuid4().hex) %}
+  {% set temp_table_name = '__dbt_tmp_schema_check_' ~ this.identifier %}
   {% set temp_relation = adapter.Relation.create(
     database=this.database,
     schema=this.schema,
     identifier=temp_table_name,
     type='table'
   ) %}
+
+  {# Drop any leftover temp table from a previous failed run #}
+  {% call statement('drop_temp_table_pre') %}
+    DROP TABLE IF EXISTS {{ temp_relation }}
+  {% endcall %}
 
   {# Create temp table from column definitions (without connector) #}
   {% call statement('create_temp_table') %}

--- a/dbt/include/confluent/macros/materializations/models/helpers.sql
+++ b/dbt/include/confluent/macros/materializations/models/helpers.sql
@@ -1,7 +1,7 @@
 {% macro skip_or_drop_existing(existing_relation, target_relation, has_select_query=true) %}
   {# If the relation already exists, either drop it (on --full-refresh) or skip.
      Returns true if the caller should skip (relation exists and no full refresh).
-     Before skipping, checks for schema drift and raises an error if detected.
+     Before skipping, checks for schema drift according to on_schema_change config.
      has_select_query: true if the model SQL is a SELECT (table, streaming_table),
                        false if it's column definitions (streaming_source). #}
   {% if existing_relation %}
@@ -9,8 +9,16 @@
       {{ drop_relation_if_exists(existing_relation) }}
       {{ return(false) }}
     {% else %}
-      {{ check_for_schema_drift(existing_relation, has_select_query) }}
-      {{ log("Relation " ~ existing_relation ~ " already exists. Skipping. Use --full-refresh to recreate.", info=True) }}
+      {% set on_schema_change = config.get('on_schema_change', 'fail') %}
+      {% if on_schema_change == 'ignore' %}
+        {{ log("Relation " ~ existing_relation ~ " already exists. Skipping without drift check (on_schema_change='ignore').", info=True) }}
+      {% elif on_schema_change == 'fail' %}
+        {{ check_for_schema_drift(existing_relation, has_select_query) }}
+        {{ log("Relation " ~ existing_relation ~ " already exists. Skipping. Use --full-refresh to recreate.", info=True) }}
+      {% else %}
+        {% set msg = "Invalid value for on_schema_change ('%s'). Expected 'ignore' or 'fail'." % on_schema_change %}
+        {% do exceptions.raise_compiler_error(msg) %}
+      {% endif %}
       {{ return(true) }}
     {% endif %}
   {% endif %}

--- a/dbt/include/confluent/macros/materializations/models/helpers.sql
+++ b/dbt/include/confluent/macros/materializations/models/helpers.sql
@@ -25,32 +25,58 @@
   {# -- Column comparison -- #}
   {% set existing_columns = get_existing_columns(existing_relation) %}
 
+  {# Determine expected columns based on model type #}
+  {% set expected_columns = none %}
   {% if has_select_query %}
     {% set expected_columns = get_expected_columns_from_query(sql) %}
-    {% if expected_columns is not none %}
-      {% set existing_col_list = [] %}
-      {% for col in existing_columns %}
-        {% do existing_col_list.append(col.column_name | lower) %}
-      {% endfor %}
+  {% else %}
+    {# For streaming_source, use column definitions from the model SQL #}
+    {% set expected_columns = get_expected_columns_from_definition(sql) %}
+  {% endif %}
 
-      {% set expected_col_list = [] %}
-      {% for col in expected_columns %}
-        {% do expected_col_list.append(col.column_name | lower) %}
-      {% endfor %}
+  {% if expected_columns is not none %}
+    {# Build maps for both name and type comparison #}
+    {% set existing_col_map = {} %}
+    {% for col in existing_columns %}
+      {% do existing_col_map.update({col.column_name | lower: col.data_type | upper}) %}
+    {% endfor %}
 
-      {% if existing_col_list | sort != expected_col_list | sort %}
+    {% set expected_col_map = {} %}
+    {% for col in expected_columns %}
+      {% do expected_col_map.update({col.column_name | lower: col.data_type | upper}) %}
+    {% endfor %}
+
+    {# Check if column names match #}
+    {% set existing_col_names = existing_col_map.keys() | sort %}
+    {% set expected_col_names = expected_col_map.keys() | sort %}
+
+    {% if existing_col_names != expected_col_names %}
+      {% set msg %}
+        Schema drift detected for '{{ existing_relation }}'.
+        Existing columns: {{ existing_col_names }}
+        Expected columns: {{ expected_col_names }}
+        Use --full-refresh to recreate the table.
+      {% endset %}
+      {% do exceptions.raise_compiler_error(msg) %}
+    {% endif %}
+
+    {# Check if data types match for each column #}
+    {% for col_name, expected_type in expected_col_map.items() %}
+      {% set existing_type = existing_col_map.get(col_name) %}
+      {% if existing_type != expected_type %}
         {% set msg %}
           Schema drift detected for '{{ existing_relation }}'.
-          Existing columns: {{ existing_col_list | sort }}
-          Expected columns: {{ expected_col_list | sort }}
+          Column '{{ col_name }}' type mismatch: existing='{{ existing_type }}', expected='{{ expected_type }}'.
           Use --full-refresh to recreate the table.
         {% endset %}
         {% do exceptions.raise_compiler_error(msg) %}
       {% endif %}
-    {% endif %}
+    {% endfor %}
   {% endif %}
 
   {# -- WITH options comparison -- #}
+  {# Only verify that user-specified options exist with correct values.
+     Allow additional options (connector defaults, system-generated) to exist. #}
   {% set expected_with = config.get('with', {}) %}
   {% if expected_with %}
     {% set existing_options = get_existing_table_options(existing_relation) %}
@@ -88,19 +114,65 @@
 
 
 {% macro get_expected_columns_from_query(model_sql) %}
-  {# Get the columns that a SELECT query would produce by running it with WHERE FALSE LIMIT 0.
-     Returns an agate table with column_name rows, or none if the query fails. #}
-  {% call statement('get_expected_columns', fetch_result=True) %}
-    SELECT * FROM ({{ model_sql }}) WHERE FALSE LIMIT 0
-  {% endcall %}
-  {% set result = load_result('get_expected_columns') %}
+  {# Get the columns that a SELECT query would produce by creating a temporary table
+     and querying its schema from INFORMATION_SCHEMA. This gives us accurate data types.
+     Returns a list of dicts with column_name and data_type. #}
 
-  {# Build a list of dicts with column_name to match get_existing_columns format #}
-  {% set expected = [] %}
-  {% for col_name in result.table.column_names %}
-    {% do expected.append({'column_name': col_name}) %}
-  {% endfor %}
-  {{ return(expected) }}
+  {# Create a unique temp table name #}
+  {% set temp_table_name = '__dbt_tmp_schema_check_' ~ (modules.datetime.datetime.utcnow().strftime('%Y%m%d%H%M%S%f')) %}
+  {% set temp_relation = adapter.Relation.create(
+    database=this.database,
+    schema=this.schema,
+    identifier=temp_table_name,
+    type='table'
+  ) %}
+
+  {# Create temp table from the query #}
+  {% call statement('create_temp_table') %}
+    CREATE TABLE {{ temp_relation }} AS {{ model_sql }} WHERE FALSE
+  {% endcall %}
+
+  {# Query INFORMATION_SCHEMA for column names and types #}
+  {% set expected_columns = get_existing_columns(temp_relation) %}
+
+  {# Drop the temp table #}
+  {% call statement('drop_temp_table') %}
+    DROP TABLE IF EXISTS {{ temp_relation }}
+  {% endcall %}
+
+  {{ return(expected_columns) }}
+{% endmacro %}
+
+
+{% macro get_expected_columns_from_definition(column_definitions) %}
+  {# Get the columns from streaming_source column definitions by creating a temp table.
+     The SQL column definitions are the source of truth, so we create a temporary table
+     to let Flink parse the schema, then query INFORMATION_SCHEMA for normalized types.
+     Returns a list of dicts with column_name and data_type. #}
+
+  {# Create a unique temp table name #}
+  {% set temp_table_name = '__dbt_tmp_schema_check_' ~ (modules.datetime.datetime.utcnow().strftime('%Y%m%d%H%M%S%f')) %}
+  {% set temp_relation = adapter.Relation.create(
+    database=this.database,
+    schema=this.schema,
+    identifier=temp_table_name,
+    type='table'
+  ) %}
+
+  {# Create temp table from column definitions (without connector) #}
+  {% call statement('create_temp_table') %}
+    CREATE TABLE {{ temp_relation }} ( {{ column_definitions }} )
+  {% endcall %}
+
+  {# Query INFORMATION_SCHEMA for column names and types #}
+  {% set expected_columns = get_existing_columns(temp_relation) %}
+
+  {# Drop the temp table #}
+  {% call statement('drop_temp_table') %}
+    DROP TABLE IF EXISTS {{ temp_relation }}
+  {% endcall %}
+
+  {{ return(expected_columns) }}
 {% endmacro %}
 
 

--- a/dbt/include/confluent/macros/materializations/models/helpers.sql
+++ b/dbt/include/confluent/macros/materializations/models/helpers.sql
@@ -119,7 +119,7 @@
      Returns a list of dicts with column_name and data_type. #}
 
   {# Create a unique temp table name #}
-  {% set temp_table_name = '__dbt_tmp_schema_check_' ~ (modules.datetime.datetime.utcnow().strftime('%Y%m%d%H%M%S%f')) %}
+  {% set temp_table_name = '__dbt_tmp_schema_check_' ~ (modules.uuid.uuid4().hex) %}
   {% set temp_relation = adapter.Relation.create(
     database=this.database,
     schema=this.schema,
@@ -154,7 +154,7 @@
      Returns a list of dicts with column_name and data_type. #}
 
   {# Create a unique temp table name #}
-  {% set temp_table_name = '__dbt_tmp_schema_check_' ~ (modules.datetime.datetime.utcnow().strftime('%Y%m%d%H%M%S%f')) %}
+  {% set temp_table_name = '__dbt_tmp_schema_check_' ~ (modules.uuid.uuid4().hex) %}
   {% set temp_relation = adapter.Relation.create(
     database=this.database,
     schema=this.schema,

--- a/dbt/include/confluent/macros/materializations/models/helpers.sql
+++ b/dbt/include/confluent/macros/materializations/models/helpers.sql
@@ -80,19 +80,14 @@
      and querying its schema from INFORMATION_SCHEMA. This gives us accurate data types.
      Returns a list of dicts with column_name and data_type. #}
 
-  {# Create a unique temp table name #}
-  {% set temp_table_name = '__dbt_tmp_schema_check_' ~ this.identifier %}
+  {# Use invocation_id to avoid collisions with user tables or concurrent runs #}
+  {% set temp_table_name = '__dbt_tmp_schema_check_' ~ this.identifier ~ '_' ~ invocation_id | replace('-', '') %}
   {% set temp_relation = adapter.Relation.create(
     database=this.database,
     schema=this.schema,
     identifier=temp_table_name,
     type='table'
   ) %}
-
-  {# Drop any leftover temp table from a previous failed run #}
-  {% call statement('drop_temp_table_pre') %}
-    DROP TABLE IF EXISTS {{ temp_relation }}
-  {% endcall %}
 
   {# Create temp table from the query #}
   {% call statement('create_temp_table') %}
@@ -120,19 +115,14 @@
      to let Flink parse and validate the schema, then query INFORMATION_SCHEMA for
      normalized types.  Returns an agate Table with column_name and data_type. #}
 
-  {# Create a unique temp table name #}
-  {% set temp_table_name = '__dbt_tmp_schema_check_' ~ this.identifier %}
+  {# Use invocation_id to avoid collisions with user tables or concurrent runs #}
+  {% set temp_table_name = '__dbt_tmp_schema_check_' ~ this.identifier ~ '_' ~ invocation_id | replace('-', '') %}
   {% set temp_relation = adapter.Relation.create(
     database=this.database,
     schema=this.schema,
     identifier=temp_table_name,
     type='table'
   ) %}
-
-  {# Drop any leftover temp table from a previous failed run #}
-  {% call statement('drop_temp_table_pre') %}
-    DROP TABLE IF EXISTS {{ temp_relation }}
-  {% endcall %}
 
   {# Create temp table from column definitions (without connector) #}
   {% call statement('create_temp_table') %}

--- a/dbt/include/confluent/macros/materializations/models/helpers.sql
+++ b/dbt/include/confluent/macros/materializations/models/helpers.sql
@@ -80,8 +80,7 @@
      and querying its schema from INFORMATION_SCHEMA. This gives us accurate data types.
      Returns a list of dicts with column_name and data_type. #}
 
-  {# Use invocation_id to avoid collisions with user tables or concurrent runs #}
-  {% set temp_table_name = '__dbt_tmp_schema_check_' ~ this.identifier ~ '_' ~ invocation_id | replace('-', '') %}
+  {% set temp_table_name = adapter.generate_schema_check_temp_name(this.identifier, invocation_id) %}
   {% set temp_relation = adapter.Relation.create(
     database=this.database,
     schema=this.schema,
@@ -115,8 +114,7 @@
      to let Flink parse and validate the schema, then query INFORMATION_SCHEMA for
      normalized types.  Returns an agate Table with column_name and data_type. #}
 
-  {# Use invocation_id to avoid collisions with user tables or concurrent runs #}
-  {% set temp_table_name = '__dbt_tmp_schema_check_' ~ this.identifier ~ '_' ~ invocation_id | replace('-', '') %}
+  {% set temp_table_name = adapter.generate_schema_check_temp_name(this.identifier, invocation_id) %}
   {% set temp_relation = adapter.Relation.create(
     database=this.database,
     schema=this.schema,

--- a/dbt/include/confluent/macros/materializations/models/helpers.sql
+++ b/dbt/include/confluent/macros/materializations/models/helpers.sql
@@ -35,8 +35,9 @@
   {% if has_select_query %}
     {% set expected_columns = get_expected_columns_from_query(sql) %}
   {% else %}
-    {# For streaming_source, parse column definitions in Python (no temp table needed) #}
-    {% set expected_columns = adapter.parse_column_definitions(sql) %}
+    {# For streaming_source, create a temp table from column definitions to let
+       Flink validate and normalize the types, then query INFORMATION_SCHEMA. #}
+    {% set expected_columns = get_expected_columns_from_definition(sql) %}
   {% endif %}
 
   {% set expected_with = config.get('with', {}) %}
@@ -99,6 +100,43 @@
     SELECT * FROM (
       {{ model_sql }}
     ) WHERE FALSE
+  {% endcall %}
+
+  {# Query INFORMATION_SCHEMA for column names and types #}
+  {% set expected_columns = get_existing_columns(temp_relation) %}
+
+  {# Drop the temp table #}
+  {% call statement('drop_temp_table') %}
+    DROP TABLE IF EXISTS {{ temp_relation }}
+  {% endcall %}
+
+  {{ return(expected_columns) }}
+{% endmacro %}
+
+
+{% macro get_expected_columns_from_definition(column_definitions) %}
+  {# Get the columns from streaming_source column definitions by creating a temp table.
+     The SQL column definitions are the source of truth, so we create a temporary table
+     to let Flink parse and validate the schema, then query INFORMATION_SCHEMA for
+     normalized types.  Returns an agate Table with column_name and data_type. #}
+
+  {# Create a unique temp table name #}
+  {% set temp_table_name = '__dbt_tmp_schema_check_' ~ this.identifier %}
+  {% set temp_relation = adapter.Relation.create(
+    database=this.database,
+    schema=this.schema,
+    identifier=temp_table_name,
+    type='table'
+  ) %}
+
+  {# Drop any leftover temp table from a previous failed run #}
+  {% call statement('drop_temp_table_pre') %}
+    DROP TABLE IF EXISTS {{ temp_relation }}
+  {% endcall %}
+
+  {# Create temp table from column definitions (without connector) #}
+  {% call statement('create_temp_table') %}
+    CREATE TABLE {{ temp_relation }} ( {{ column_definitions }} )
   {% endcall %}
 
   {# Query INFORMATION_SCHEMA for column names and types #}

--- a/dbt/include/confluent/macros/materializations/models/helpers.sql
+++ b/dbt/include/confluent/macros/materializations/models/helpers.sql
@@ -1,15 +1,127 @@
-{% macro skip_or_drop_existing(existing_relation, target_relation) %}
-  {# If the relation already exists, either drop it (on --full-refresh) or skip re-creation.
-     Returns early from the calling materialization if skipping. #}
-  {# TODO: Compare the existing relation's schema against the expected one and raise
-     a compilation error if they differ (e.g., column changes that require --full-refresh). #}
+{% macro skip_or_drop_existing(existing_relation, target_relation, has_select_query=true) %}
+  {# If the relation already exists, either drop it (on --full-refresh) or skip.
+     Returns true if the caller should skip (relation exists and no full refresh).
+     Before skipping, checks for schema drift and raises an error if detected.
+     has_select_query: true if the model SQL is a SELECT (table, streaming_table),
+                       false if it's column definitions (streaming_source). #}
   {% if existing_relation %}
     {% if should_full_refresh() %}
       {{ drop_relation_if_exists(existing_relation) }}
+      {{ return(false) }}
     {% else %}
+      {{ check_for_schema_drift(existing_relation, has_select_query) }}
       {{ log("Relation " ~ existing_relation ~ " already exists. Skipping. Use --full-refresh to recreate.", info=True) }}
-      {{ run_hooks(post_hooks, inside_transaction=False) }}
-      {{ return({'relations': [target_relation]}) }}
+      {{ return(true) }}
     {% endif %}
   {% endif %}
+  {{ return(false) }}
+{% endmacro %}
+
+
+{% macro check_for_schema_drift(existing_relation, has_select_query) %}
+  {# Compare the existing table's columns and WITH options against what the model
+     would produce. Raises a compilation error if there is any drift. #}
+
+  {# -- Column comparison -- #}
+  {% set existing_columns = get_existing_columns(existing_relation) %}
+
+  {% if has_select_query %}
+    {% set expected_columns = get_expected_columns_from_query(sql) %}
+    {% if expected_columns is not none %}
+      {% set existing_col_list = [] %}
+      {% for col in existing_columns %}
+        {% do existing_col_list.append(col.column_name | lower) %}
+      {% endfor %}
+
+      {% set expected_col_list = [] %}
+      {% for col in expected_columns %}
+        {% do expected_col_list.append(col.column_name | lower) %}
+      {% endfor %}
+
+      {% if existing_col_list | sort != expected_col_list | sort %}
+        {% set msg %}
+          Schema drift detected for '{{ existing_relation }}'.
+          Existing columns: {{ existing_col_list | sort }}
+          Expected columns: {{ expected_col_list | sort }}
+          Use --full-refresh to recreate the table.
+        {% endset %}
+        {% do exceptions.raise_compiler_error(msg) %}
+      {% endif %}
+    {% endif %}
+  {% endif %}
+
+  {# -- WITH options comparison -- #}
+  {% set expected_with = config.get('with', {}) %}
+  {% if expected_with %}
+    {% set existing_options = get_existing_table_options(existing_relation) %}
+    {% for key, value in expected_with.items() %}
+      {% if existing_options.get(key) != value %}
+        {% set msg %}
+          Table options drift detected for '{{ existing_relation }}'.
+          Option '{{ key }}': existing='{{ existing_options.get(key, "<not set>") }}', expected='{{ value }}'.
+          Use --full-refresh to recreate the table.
+        {% endset %}
+        {% do exceptions.raise_compiler_error(msg) %}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+{% endmacro %}
+
+
+{% macro get_existing_columns(relation) %}
+  {# Fetch column name and type from INFORMATION_SCHEMA.COLUMNS for the given relation. #}
+  {% call statement('get_existing_columns', fetch_result=True) %}
+    SELECT
+      COLUMN_NAME as column_name,
+      FULL_DATA_TYPE as data_type
+    FROM
+      INFORMATION_SCHEMA.`COLUMNS`
+    WHERE
+      TABLE_CATALOG_ID = '{{ relation.database }}'
+      AND TABLE_SCHEMA = '{{ relation.schema }}'
+      AND TABLE_NAME = '{{ relation.identifier }}'
+      AND IS_HIDDEN = 'NO'
+  {% endcall %}
+  {% set result = load_result('get_existing_columns') %}
+  {{ return(result.table) }}
+{% endmacro %}
+
+
+{% macro get_expected_columns_from_query(model_sql) %}
+  {# Get the columns that a SELECT query would produce by running it with WHERE FALSE LIMIT 0.
+     Returns an agate table with column_name rows, or none if the query fails. #}
+  {% call statement('get_expected_columns', fetch_result=True) %}
+    SELECT * FROM ({{ model_sql }}) WHERE FALSE LIMIT 0
+  {% endcall %}
+  {% set result = load_result('get_expected_columns') %}
+
+  {# Build a list of dicts with column_name to match get_existing_columns format #}
+  {% set expected = [] %}
+  {% for col_name in result.table.column_names %}
+    {% do expected.append({'column_name': col_name}) %}
+  {% endfor %}
+  {{ return(expected) }}
+{% endmacro %}
+
+
+{% macro get_existing_table_options(relation) %}
+  {# Fetch WITH options from INFORMATION_SCHEMA.TABLE_OPTIONS for the given relation.
+     Returns a dict of {option_key: option_value}. #}
+  {% call statement('get_existing_table_options', fetch_result=True) %}
+    SELECT
+      OPTION_KEY,
+      OPTION_VALUE
+    FROM
+      INFORMATION_SCHEMA.`TABLE_OPTIONS`
+    WHERE
+      TABLE_CATALOG_ID = '{{ relation.database }}'
+      AND TABLE_SCHEMA = '{{ relation.schema }}'
+      AND TABLE_NAME = '{{ relation.identifier }}'
+  {% endcall %}
+  {% set result = load_result('get_existing_table_options') %}
+  {% set options = {} %}
+  {% for row in result.table %}
+    {% do options.update({row['OPTION_KEY']: row['OPTION_VALUE']}) %}
+  {% endfor %}
+  {{ return(options) }}
 {% endmacro %}

--- a/dbt/include/confluent/macros/materializations/models/helpers.sql
+++ b/dbt/include/confluent/macros/materializations/models/helpers.sql
@@ -30,75 +30,28 @@
   {# Compare the existing table's columns and WITH options against what the model
      would produce. Raises a compilation error if there is any drift. #}
 
-  {# -- Column comparison -- #}
   {% set existing_columns = get_existing_columns(existing_relation) %}
 
-  {# Determine expected columns based on model type #}
-  {% set expected_columns = none %}
   {% if has_select_query %}
     {% set expected_columns = get_expected_columns_from_query(sql) %}
   {% else %}
-    {# For streaming_source, use column definitions from the model SQL #}
-    {% set expected_columns = get_expected_columns_from_definition(sql) %}
+    {# For streaming_source, parse column definitions in Python (no temp table needed) #}
+    {% set expected_columns = adapter.parse_column_definitions(sql) %}
   {% endif %}
 
-  {% if expected_columns is not none %}
-    {# Build maps for both name and type comparison #}
-    {% set existing_col_map = {} %}
-    {% for col in existing_columns %}
-      {% do existing_col_map.update({col.column_name | lower: col.data_type | upper}) %}
-    {% endfor %}
-
-    {% set expected_col_map = {} %}
-    {% for col in expected_columns %}
-      {% do expected_col_map.update({col.column_name | lower: col.data_type | upper}) %}
-    {% endfor %}
-
-    {# Check if column names match #}
-    {% set existing_col_names = existing_col_map.keys() | sort %}
-    {% set expected_col_names = expected_col_map.keys() | sort %}
-
-    {% if existing_col_names != expected_col_names %}
-      {% set msg %}
-        Schema drift detected for '{{ existing_relation }}'.
-        Existing columns: {{ existing_col_names }}
-        Expected columns: {{ expected_col_names }}
-        Use --full-refresh to recreate the table.
-      {% endset %}
-      {% do exceptions.raise_compiler_error(msg) %}
-    {% endif %}
-
-    {# Check if data types match for each column #}
-    {% for col_name, expected_type in expected_col_map.items() %}
-      {% set existing_type = existing_col_map.get(col_name) %}
-      {% if existing_type != expected_type %}
-        {% set msg %}
-          Schema drift detected for '{{ existing_relation }}'.
-          Column '{{ col_name }}' type mismatch: existing='{{ existing_type }}', expected='{{ expected_type }}'.
-          Use --full-refresh to recreate the table.
-        {% endset %}
-        {% do exceptions.raise_compiler_error(msg) %}
-      {% endif %}
-    {% endfor %}
-  {% endif %}
-
-  {# -- WITH options comparison -- #}
-  {# Only verify that user-specified options exist with correct values.
-     Allow additional options (connector defaults, system-generated) to exist. #}
   {% set expected_with = config.get('with', {}) %}
+  {% set existing_options = {} %}
   {% if expected_with %}
     {% set existing_options = get_existing_table_options(existing_relation) %}
-    {% for key, value in expected_with.items() %}
-      {% if existing_options.get(key) != value %}
-        {% set msg %}
-          Table options drift detected for '{{ existing_relation }}'.
-          Option '{{ key }}': existing='{{ existing_options.get(key, "<not set>") }}', expected='{{ value }}'.
-          Use --full-refresh to recreate the table.
-        {% endset %}
-        {% do exceptions.raise_compiler_error(msg) %}
-      {% endif %}
-    {% endfor %}
   {% endif %}
+
+  {% do adapter.check_schema_drift(
+    existing_relation | string,
+    existing_columns,
+    expected_columns,
+    expected_with,
+    existing_options
+  ) %}
 {% endmacro %}
 
 
@@ -146,43 +99,6 @@
     SELECT * FROM (
       {{ model_sql }}
     ) WHERE FALSE
-  {% endcall %}
-
-  {# Query INFORMATION_SCHEMA for column names and types #}
-  {% set expected_columns = get_existing_columns(temp_relation) %}
-
-  {# Drop the temp table #}
-  {% call statement('drop_temp_table') %}
-    DROP TABLE IF EXISTS {{ temp_relation }}
-  {% endcall %}
-
-  {{ return(expected_columns) }}
-{% endmacro %}
-
-
-{% macro get_expected_columns_from_definition(column_definitions) %}
-  {# Get the columns from streaming_source column definitions by creating a temp table.
-     The SQL column definitions are the source of truth, so we create a temporary table
-     to let Flink parse the schema, then query INFORMATION_SCHEMA for normalized types.
-     Returns a list of dicts with column_name and data_type. #}
-
-  {# Create a unique temp table name #}
-  {% set temp_table_name = '__dbt_tmp_schema_check_' ~ this.identifier %}
-  {% set temp_relation = adapter.Relation.create(
-    database=this.database,
-    schema=this.schema,
-    identifier=temp_table_name,
-    type='table'
-  ) %}
-
-  {# Drop any leftover temp table from a previous failed run #}
-  {% call statement('drop_temp_table_pre') %}
-    DROP TABLE IF EXISTS {{ temp_relation }}
-  {% endcall %}
-
-  {# Create temp table from column definitions (without connector) #}
-  {% call statement('create_temp_table') %}
-    CREATE TABLE {{ temp_relation }} ( {{ column_definitions }} )
   {% endcall %}
 
   {# Query INFORMATION_SCHEMA for column names and types #}

--- a/dbt/include/confluent/macros/materializations/models/helpers.sql
+++ b/dbt/include/confluent/macros/materializations/models/helpers.sql
@@ -1,15 +1,15 @@
-{% macro drop_if_full_refresh(relation) %}
-  -- If full refresh is set to true, drop the relation if it exists.
-  -- Otherwise, raise an error and specify you need to set full_refresh to true.
-  {% if relation %}
+{% macro skip_or_drop_existing(existing_relation, target_relation) %}
+  {# If the relation already exists, either drop it (on --full-refresh) or skip re-creation.
+     Returns early from the calling materialization if skipping. #}
+  {# TODO: Compare the existing relation's schema against the expected one and raise
+     a compilation error if they differ (e.g., column changes that require --full-refresh). #}
+  {% if existing_relation %}
     {% if should_full_refresh() %}
-      {{ drop_relation_if_exists(relation) }}
+      {{ drop_relation_if_exists(existing_relation) }}
     {% else %}
-      {% set msg %}
-        Relation '{{ relation }}' already exists.
-        Set full_refresh to true if you want to overwrite the existing relation
-      {% endset %}
-      {% do exceptions.raise_compiler_error(msg) %}
+      {{ log("Relation " ~ existing_relation ~ " already exists. Skipping. Use --full-refresh to recreate.", info=True) }}
+      {{ run_hooks(post_hooks, inside_transaction=False) }}
+      {{ return({'relations': [target_relation]}) }}
     {% endif %}
   {% endif %}
 {% endmacro %}

--- a/dbt/include/confluent/macros/materializations/models/materialized_view.sql
+++ b/dbt/include/confluent/macros/materializations/models/materialized_view.sql
@@ -1,26 +1,7 @@
-{% materialization materialized_view, adapter='confluent' %}
-    {% set existing_relation = load_cached_relation(this) %}
-    {% set target_relation = this.incorporate(type=this.MaterializedView) %}
-
-    {{ run_hooks(pre_hooks, inside_transaction=False) }}
-
-    -- drop the relation if it exists already in the database
-    {{ drop_relation_if_exists(existing_relation) }}
-
-    -- `BEGIN` happens here:
-    {{ run_hooks(pre_hooks, inside_transaction=True) }}
-
-    -- build model
-    {% call statement('main') -%}
-        {{ get_create_materialized_view_as_sql(target_relation, sql) }}
-    {%- endcall %}
-
-    {% do persist_docs(target_relation, model) %}
-    {{ run_hooks(post_hooks, inside_transaction=True) }}
-    {{ adapter.commit() }}
-    {{ run_hooks(post_hooks, inside_transaction=False) }}
-
-    {{ return({'relations': [target_relation]}) }}
-{% endmaterialization %}
-
-
+{% materialization materialized_view, adapter='confluent' -%}
+    {% set msg %}
+      This adapter (confluent) does not support materialized_view materialization.
+      Use 'table' instead — in Confluent Flink, materialized views are implemented as CTAS tables.
+    {% endset %}
+    {% do exceptions.raise_compiler_error(msg) %}
+{%- endmaterialization %}

--- a/dbt/include/confluent/macros/materializations/models/streaming_source.sql
+++ b/dbt/include/confluent/macros/materializations/models/streaming_source.sql
@@ -17,7 +17,12 @@
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
   -- TODO: Support altering table options without full refresh (ALTER TABLE ... SET).
-  {{ skip_or_drop_existing(existing_relation, target_relation) }}
+  {% if skip_or_drop_existing(existing_relation, target_relation, has_select_query=false) %}
+    {# dbt requires a 'main' statement result even when skipping #}
+    {% call noop_statement('main', 'SKIP') %}{% endcall %}
+    {{ run_hooks(post_hooks, inside_transaction=False) }}
+    {{ return({'relations': [target_relation]}) }}
+  {% endif %}
 
   -- See comment above about calling hooks
   {{ run_hooks(pre_hooks, inside_transaction=True) }}

--- a/dbt/include/confluent/macros/materializations/models/streaming_source.sql
+++ b/dbt/include/confluent/macros/materializations/models/streaming_source.sql
@@ -16,10 +16,8 @@
   -- break any assumption made by the framework.
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
-  -- If user asks for full refresh, we drop any pre existing relation.
-  -- Otherwise, we fail, because we can't alter a table.
-  -- TODO: We can actually alter the options, so we should allow that at least.
-  {{ drop_if_full_refresh(existing_relation) }}
+  -- TODO: Support altering table options without full refresh (ALTER TABLE ... SET).
+  {{ skip_or_drop_existing(existing_relation, target_relation) }}
 
   -- See comment above about calling hooks
   {{ run_hooks(pre_hooks, inside_transaction=True) }}

--- a/dbt/include/confluent/macros/materializations/models/streaming_table.sql
+++ b/dbt/include/confluent/macros/materializations/models/streaming_table.sql
@@ -16,7 +16,12 @@
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
   -- TODO: Support altering table options without full refresh (ALTER TABLE ... SET).
-  {{ skip_or_drop_existing(existing_relation, target_relation) }}
+  {% if skip_or_drop_existing(existing_relation, target_relation) %}
+    {# dbt requires a 'main' statement result even when skipping #}
+    {% call noop_statement('main', 'SKIP') %}{% endcall %}
+    {{ run_hooks(post_hooks, inside_transaction=False) }}
+    {{ return({'relations': [target_relation]}) }}
+  {% endif %}
 
   -- See comment above about calling hooks
   {{ run_hooks(pre_hooks, inside_transaction=True) }}

--- a/dbt/include/confluent/macros/materializations/models/streaming_table.sql
+++ b/dbt/include/confluent/macros/materializations/models/streaming_table.sql
@@ -15,10 +15,8 @@
   -- any assumption from the framework
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
-  -- If user asks for full refresh, we drop any pre existing relation.
-  -- Otherwise, we fail, because we can't alter a table.
-  -- TODO: We can actually alter the options, so we should allow that at least.
-  {{ drop_if_full_refresh(existing_relation) }}
+  -- TODO: Support altering table options without full refresh (ALTER TABLE ... SET).
+  {{ skip_or_drop_existing(existing_relation, target_relation) }}
 
   -- See comment above about calling hooks
   {{ run_hooks(pre_hooks, inside_transaction=True) }}

--- a/dbt/include/confluent/macros/materializations/models/table.sql
+++ b/dbt/include/confluent/macros/materializations/models/table.sql
@@ -4,8 +4,7 @@
 
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
-  -- Drop the existing relation if it already exists and full refresh is set
-  {{ drop_if_full_refresh(existing_relation) }}
+  {{ skip_or_drop_existing(existing_relation, target_relation) }}
 
   -- `BEGIN` happens here:
   {{ run_hooks(pre_hooks, inside_transaction=True) }}

--- a/dbt/include/confluent/macros/materializations/models/table.sql
+++ b/dbt/include/confluent/macros/materializations/models/table.sql
@@ -4,7 +4,12 @@
 
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
-  {{ skip_or_drop_existing(existing_relation, target_relation) }}
+  {% if skip_or_drop_existing(existing_relation, target_relation) %}
+    {# dbt requires a 'main' statement result even when skipping #}
+    {% call noop_statement('main', 'SKIP') %}{% endcall %}
+    {{ run_hooks(post_hooks, inside_transaction=False) }}
+    {{ return({'relations': [target_relation]}) }}
+  {% endif %}
 
   -- `BEGIN` happens here:
   {{ run_hooks(pre_hooks, inside_transaction=True) }}

--- a/dbt/include/confluent/macros/relations/materialized_view/alter.sql
+++ b/dbt/include/confluent/macros/relations/materialized_view/alter.sql
@@ -1,5 +1,0 @@
-{% macro confluent__get_materialized_view_configuration_changes(existing_relation, new_config) %}
-  {# Return none to indicate no configuration changes detected.
-     This causes the materialization to call refresh_materialized_view (which is a no-op). #}
-  {{ return(none) }}
-{% endmacro %}

--- a/dbt/include/confluent/macros/relations/materialized_view/create.sql
+++ b/dbt/include/confluent/macros/relations/materialized_view/create.sql
@@ -1,7 +1,0 @@
-{% macro confluent__get_create_materialized_view_as_sql(relation, sql) -%}
-  {# In Confluent Flink SQL, materialized views are implemented as tables
-     created via CTAS (CREATE TABLE AS SELECT). These tables are continuously
-     updated by streaming queries, making them functionally equivalent to
-     materialized views in other systems. #}
-  {{ return(create_table_as(False, relation, sql)) }}
-{%- endmacro %}

--- a/dbt/include/confluent/macros/relations/materialized_view/refresh.sql
+++ b/dbt/include/confluent/macros/relations/materialized_view/refresh.sql
@@ -1,5 +1,0 @@
-{% macro confluent__refresh_materialized_view(relation) %}
-  {# In Confluent Flink, CTAS tables are continuously updated by streaming
-     queries - there's no manual refresh needed. Return empty string (no-op). #}
-  {{ return('') }}
-{% endmacro %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ Repository = "https://github.com/confluentinc/dbt-confluent"
 confluent = "dbt.adapters.confluent"
 
 [tool.pytest.ini_options]
-testpaths = ["tests/functional"]
+testpaths = ["tests/functional", "tests/unit"]
 addopts = "-v --color=yes"
 env_files = ["test.env"]
 

--- a/tests/functional/adapter/test_materialized_views.py
+++ b/tests/functional/adapter/test_materialized_views.py
@@ -1,115 +1,22 @@
 import pytest
 
-from dbt.adapters.base.relation import BaseRelation
-from dbt.tests.adapter.materialized_view.basic import MaterializedViewBasic
-from dbt.tests.util import (
-    get_model_file,
-    run_dbt,
-    run_dbt_and_capture,
-    set_model_file,
-)
+from dbt.tests.util import run_dbt
 from tests.functional.adapter.fixtures import ConfluentFixtures
 
+MY_MV_MODEL = """
+{{ config(materialized='materialized_view') }}
+select 1 as id
+"""
 
-class TestConfluentMaterializedViewsBasic(ConfluentFixtures, MaterializedViewBasic):
-    """
-    Confluent Flink SQL implements materialized views as CTAS tables.
-    INFORMATION_SCHEMA reports them as 'BASE TABLE' rather than 'MATERIALIZED VIEW'.
 
-    This means some upstream tests are redundant (table-to-MV swap is invisible
-    since both are 'table' in Confluent), and the refresh test doesn't apply
-    because CTAS tables are continuously updated by Flink.
-    """
+class TestMaterializedViewNotSupported(ConfluentFixtures):
+    """materialized_view should raise a compilation error directing users to use table instead."""
 
-    @pytest.fixture(scope="class", autouse=True)
-    def cleanup(self, project):
-        run_dbt(["seed"])
-        yield
-        project.run_sql(f"drop table if exists my_seed")
-        project.run_sql(f"drop table if exists my_table")
-        project.run_sql(f"drop table if exists my_view")
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"my_mv.sql": MY_MV_MODEL}
 
-    @pytest.fixture(scope="function", autouse=True)
-    def setup(self, project, my_materialized_view):
-        run_dbt(["run", "--models", my_materialized_view.identifier, "--full-refresh"])
-        initial_model = get_model_file(project, my_materialized_view)
-        yield
-        set_model_file(project, my_materialized_view, initial_model)
-        project.run_sql(f"drop table if exists {my_materialized_view}")
-
-    @staticmethod
-    def query_relation_type(project, relation: BaseRelation) -> str | None:
-        """Query the relation type from INFORMATION_SCHEMA."""
-        sql = f"""
-          SELECT TABLE_TYPE
-          FROM INFORMATION_SCHEMA.`TABLES`
-          WHERE TABLE_CATALOG_ID = '{relation.database}'
-            AND TABLE_SCHEMA = '{relation.schema}'
-            AND TABLE_NAME = '{relation.identifier}'
-        """
-        result = project.run_sql(sql, fetch="one")
-        if result is None:
-            return None
-
-        table_type = result[0][0]
-        type_mapping = {
-            "BASE TABLE": "table",
-            "VIEW": "view",
-        }
-        return type_mapping.get(table_type, table_type.lower().replace(" ", "_"))
-
-    # -- Tests that are meaningful for Confluent --
-
-    def test_materialized_view_create(self, project, my_materialized_view):
-        assert self.query_relation_type(project, my_materialized_view) == "table"
-
-    def test_materialized_view_create_idempotent(self, project, my_materialized_view):
-        assert self.query_relation_type(project, my_materialized_view) == "table"
-        run_dbt(["run", "--models", my_materialized_view.identifier])
-        assert self.query_relation_type(project, my_materialized_view) == "table"
-
-    def test_materialized_view_full_refresh(self, project, my_materialized_view):
-        _, logs = run_dbt_and_capture(
-            ["--debug", "run", "--models", my_materialized_view.identifier, "--full-refresh"]
-        )
-        assert self.query_relation_type(project, my_materialized_view) == "table"
-
-    def test_materialized_view_replaces_view(self, project, my_view):
-        """A real view is replaced by a CTAS table when switching to materialized_view."""
-        run_dbt(["run", "--models", my_view.identifier])
-        assert self.query_relation_type(project, my_view) == "view"
-
-        self.swap_view_to_materialized_view(project, my_view)
-
-        run_dbt(["run", "--models", my_view.identifier])
-        assert self.query_relation_type(project, my_view) == "table"
-
-    def test_view_replaces_materialized_view(self, project, my_materialized_view):
-        """A CTAS table is replaced by a real view when switching to view."""
-        run_dbt(["run", "--models", my_materialized_view.identifier])
-        assert self.query_relation_type(project, my_materialized_view) == "table"
-
-        self.swap_materialized_view_to_view(project, my_materialized_view)
-
-        run_dbt(["run", "--models", my_materialized_view.identifier])
-        assert self.query_relation_type(project, my_materialized_view) == "view"
-
-    # -- Skipped: redundant because both table and materialized_view are 'table' in Confluent --
-
-    @pytest.mark.skip(
-        "Redundant: both table and materialized_view are reported as 'table' in Confluent"
-    )
-    def test_materialized_view_replaces_table(self, project, my_table):
-        pass
-
-    @pytest.mark.skip(
-        "Redundant: both table and materialized_view are reported as 'table' in Confluent"
-    )
-    def test_table_replaces_materialized_view(self, project, my_materialized_view):
-        pass
-
-    @pytest.mark.skip("CTAS tables are continuously updated by Flink - no manual refresh needed")
-    def test_materialized_view_only_updates_after_refresh(
-        self, project, my_materialized_view, my_seed
-    ):
-        pass
+    def test_materialized_view_raises_error(self, project):
+        result = run_dbt(["run"], expect_pass=False)
+        assert len(result) == 1
+        assert result[0].status == "error"

--- a/tests/functional/adapter/test_materialized_views.py
+++ b/tests/functional/adapter/test_materialized_views.py
@@ -19,4 +19,4 @@ class TestMaterializedViewNotSupported(ConfluentFixtures):
     def test_materialized_view_raises_error(self, project):
         result = run_dbt(["run"], expect_pass=False)
         assert len(result) == 1
-        assert result[0].status == "error"
+        assert result[0].status.name == "Error"

--- a/tests/functional/adapter/test_regressions.py
+++ b/tests/functional/adapter/test_regressions.py
@@ -5,7 +5,6 @@ import pytest
 from dbt.tests.util import run_dbt
 from tests.functional.adapter.fixtures import ConfluentFixtures
 
-
 # Test for issue with window functions producing NOT NULL constraints
 # in FULL_DATA_TYPE which break CAST expressions in get_empty_schema_sql
 

--- a/tests/functional/adapter/test_regressions.py
+++ b/tests/functional/adapter/test_regressions.py
@@ -115,6 +115,6 @@ class TestWindowFunctionConstraintsInDataType(ConfluentFixtures):
         assert window_table_result.status.name == "Error", "Expected window_table to fail"
 
         # Check error message contains key guidance
-        assert "constraint keywords in the data_type field" in window_table_result.message
-        assert "constraints must be specified separately" in window_table_result.message
-        assert "constraints:" in window_table_result.message
+        assert "constraint keyword in the data_type field" in window_table_result.message
+        assert "cannot appear in data type definitions" in window_table_result.message
+        assert "constraints" in window_table_result.message.lower()

--- a/tests/functional/adapter/test_regressions.py
+++ b/tests/functional/adapter/test_regressions.py
@@ -106,9 +106,9 @@ class TestWindowFunctionConstraintsInDataType(ConfluentFixtures):
 
         # Find the window_table result
         window_table_result = None
-        for r in results:
-            if r.node.name == "window_table":
-                window_table_result = r
+        for res in results:
+            if res.node.name == "window_table":
+                window_table_result = res
                 break
 
         assert window_table_result is not None, "window_table not found in results"

--- a/tests/functional/adapter/test_regressions.py
+++ b/tests/functional/adapter/test_regressions.py
@@ -1,0 +1,120 @@
+"""Tests for specific regressions and bug fixes."""
+
+import pytest
+
+from dbt.tests.util import run_dbt
+from tests.functional.adapter.fixtures import ConfluentFixtures
+
+
+# Test for issue with window functions producing NOT NULL constraints
+# in FULL_DATA_TYPE which break CAST expressions in get_empty_schema_sql
+
+SOURCE_FOR_WINDOW_TEST = """
+{{ config(
+    materialized='streaming_source',
+    connector='faker',
+    with={
+        'rows-per-second': '1',
+        'number-of-rows': '100',
+    }
+) }}
+`order_id` BIGINT,
+`price` DECIMAL(10, 2),
+`order_time` TIMESTAMP(3),
+WATERMARK FOR order_time AS order_time - INTERVAL '5' SECOND,
+PRIMARY KEY(`order_id`) NOT ENFORCED
+"""
+
+STREAMING_TABLE_WITH_WINDOW_FUNCTIONS = """
+{{ config(
+    materialized='streaming_table',
+    contract={'enforced': true}
+) }}
+SELECT *
+FROM (
+    SELECT *,
+        ROW_NUMBER() OVER (PARTITION BY window_start, window_end
+                          ORDER BY total_price DESC) AS rownum
+    FROM (
+        SELECT window_start,
+               window_end,
+               order_id,
+               SUM(price) AS total_price,
+               COUNT(*) AS cnt
+        FROM TABLE(TUMBLE(TABLE {{ ref('source_for_window_test') }},
+                         DESCRIPTOR(order_time),
+                         INTERVAL '10' MINUTES))
+        GROUP BY window_start, window_end, order_id
+    )
+)
+WHERE rownum <= 5
+"""
+
+WINDOW_TABLE_MODELS_YML = """
+models:
+  - name: window_table
+    columns:
+      - name: window_start
+        data_type: TIMESTAMP(3) NOT NULL
+      - name: window_end
+        data_type: TIMESTAMP(3) NOT NULL
+      - name: order_id
+        data_type: BIGINT NOT NULL
+      - name: total_price
+        data_type: DECIMAL(38,2) NOT NULL
+      - name: cnt
+        data_type: BIGINT NOT NULL
+      - name: rownum
+        data_type: BIGINT NOT NULL
+"""
+
+
+class TestWindowFunctionConstraintsInDataType(ConfluentFixtures):
+    """Test validation of malformed YAML with constraints in data_type field.
+
+    Users might mistakenly put constraint keywords (NOT NULL, VIRTUAL, etc.)
+    directly in the data_type field instead of using the constraints section.
+    This test ensures we catch this early and provide a clear, actionable error.
+    """
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self, unique_schema):
+        return {
+            "models": {"+schema": unique_schema},
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "source_for_window_test.sql": SOURCE_FOR_WINDOW_TEST,
+            "window_table.sql": STREAMING_TABLE_WITH_WINDOW_FUNCTIONS,
+            "models.yml": WINDOW_TABLE_MODELS_YML,
+        }
+
+    @pytest.fixture(scope="class", autouse=True)
+    def setup_and_teardown(self, project):
+        yield
+        project.run_sql("drop table if exists source_for_window_test")
+        project.run_sql("drop table if exists window_table")
+
+    def test_constraint_in_data_type_error(self, project):
+        """Should error with clear message when constraints are in data_type field."""
+        results = run_dbt(["run", "--full-refresh"], expect_pass=False)
+
+        # Should have 1 success (source) and 1 error (window_table)
+        assert len(results) == 2
+
+        # Find the window_table result
+        window_table_result = None
+        for r in results:
+            if r.node.name == "window_table":
+                window_table_result = r
+                break
+
+        assert window_table_result is not None, "window_table not found in results"
+        assert window_table_result.status.name == "Error", "Expected window_table to fail"
+
+        # Check error message contains key guidance
+        assert "constraint keywords in the data_type field" in window_table_result.message
+        assert "constraints must be specified separately" in window_table_result.message
+        assert "constraints:" in window_table_result.message

--- a/tests/functional/adapter/test_schema_drift.py
+++ b/tests/functional/adapter/test_schema_drift.py
@@ -25,11 +25,14 @@ def get_result_by_name(results, name):
     return None
 
 
-def assert_result_has_status(results, name, expected_status):
-    """Assert that a specific result has the expected status."""
+def assert_drift_error(results, name):
+    """Assert that a specific result failed with a drift detection error."""
     result = get_result_by_name(results, name)
     assert result is not None, f"{name} not found in results"
-    assert result.status == expected_status, f"{name} expected status '{expected_status}' but got '{result.status}'"
+    assert result.status == "error", f"{name} expected status 'error' but got '{result.status}'"
+    assert "drift detected" in result.message.lower(), (
+        f"{name} error was not a drift error: {result.message}"
+    )
 
 # -- Table (CTAS) models --
 
@@ -281,17 +284,17 @@ class TestTableColumnDrift(ConfluentFixtures):
     def test_extra_column_detected(self, project):
         set_model_file(project, relation(project, "my_table"), TABLE_MODEL_EXTRA_COLUMN)
         result = run_dbt(["run"], expect_pass=False)
-        assert_result_has_status(result, "my_table", "error")
+        assert_drift_error(result, "my_table")
 
     def test_removed_column_detected(self, project):
         set_model_file(project, relation(project, "my_table"), TABLE_MODEL_REMOVED_COLUMN)
         result = run_dbt(["run"], expect_pass=False)
-        assert_result_has_status(result, "my_table", "error")
+        assert_drift_error(result, "my_table")
 
     def test_renamed_column_detected(self, project):
         set_model_file(project, relation(project, "my_table"), TABLE_MODEL_RENAMED_COLUMN)
         result = run_dbt(["run"], expect_pass=False)
-        assert_result_has_status(result, "my_table", "error")
+        assert_drift_error(result, "my_table")
 
     def test_reordered_columns_not_detected(self, project):
         """Column reordering is not considered drift — order doesn't matter for Kafka tables."""
@@ -315,7 +318,7 @@ class TestTableColumnDrift(ConfluentFixtures):
         """Changing column data types should raise an error without --full-refresh."""
         set_model_file(project, relation(project, "my_table"), TABLE_MODEL_TYPE_CHANGE)
         result = run_dbt(["run"], expect_pass=False)
-        assert_result_has_status(result, "my_table", "error")
+        assert_drift_error(result, "my_table")
 
 
 class TestStreamingTableIdempotent(ConfluentFixtures):
@@ -381,18 +384,18 @@ class TestStreamingTableOptionsDrift(ConfluentFixtures):
     def test_changed_options_detected(self, project):
         set_model_file(project, relation(project, "my_streaming_table"), STREAMING_TABLE_MODEL_DIFFERENT_OPTIONS)
         result = run_dbt(["run"], expect_pass=False)
-        assert_result_has_status(result, "my_streaming_table", "error")
+        assert_drift_error(result, "my_streaming_table")
 
     def test_column_drift_detected(self, project):
         set_model_file(project, relation(project, "my_streaming_table"), STREAMING_TABLE_MODEL_EXTRA_COLUMN)
         result = run_dbt(["run"], expect_pass=False)
-        assert_result_has_status(result, "my_streaming_table", "error")
+        assert_drift_error(result, "my_streaming_table")
 
     def test_type_change_detected(self, project):
         """Changing column data types should raise an error without --full-refresh."""
         set_model_file(project, relation(project, "my_streaming_table"), STREAMING_TABLE_MODEL_TYPE_CHANGE)
         result = run_dbt(["run"], expect_pass=False)
-        assert_result_has_status(result, "my_streaming_table", "error")
+        assert_drift_error(result, "my_streaming_table")
 
 
 class TestStreamingSourceIdempotent(ConfluentFixtures):
@@ -449,31 +452,31 @@ class TestStreamingSourceOptionsDrift(ConfluentFixtures):
     def test_changed_options_detected(self, project):
         set_model_file(project, relation(project, "my_source"), STREAMING_SOURCE_MODEL_DIFFERENT_OPTIONS)
         result = run_dbt(["run"], expect_pass=False)
-        assert_result_has_status(result, "my_source", "error")
+        assert_drift_error(result, "my_source")
 
     def test_extra_column_detected(self, project):
         """Adding a column should raise an error without --full-refresh."""
         set_model_file(project, relation(project, "my_source"), STREAMING_SOURCE_MODEL_EXTRA_COLUMN)
         result = run_dbt(["run"], expect_pass=False)
-        assert_result_has_status(result, "my_source", "error")
+        assert_drift_error(result, "my_source")
 
     def test_removed_column_detected(self, project):
         """Removing a column should raise an error without --full-refresh."""
         set_model_file(project, relation(project, "my_source"), STREAMING_SOURCE_MODEL_REMOVED_COLUMN)
         result = run_dbt(["run"], expect_pass=False)
-        assert_result_has_status(result, "my_source", "error")
+        assert_drift_error(result, "my_source")
 
     def test_renamed_column_detected(self, project):
         """Renaming a column should raise an error without --full-refresh."""
         set_model_file(project, relation(project, "my_source"), STREAMING_SOURCE_MODEL_RENAMED_COLUMN)
         result = run_dbt(["run"], expect_pass=False)
-        assert_result_has_status(result, "my_source", "error")
+        assert_drift_error(result, "my_source")
 
     def test_type_change_detected(self, project):
         """Changing column data types should raise an error without --full-refresh."""
         set_model_file(project, relation(project, "my_source"), STREAMING_SOURCE_MODEL_TYPE_CHANGE)
         result = run_dbt(["run"], expect_pass=False)
-        assert_result_has_status(result, "my_source", "error")
+        assert_drift_error(result, "my_source")
 
 
 # -- on_schema_drift='ignore' tests --

--- a/tests/functional/adapter/test_schema_drift.py
+++ b/tests/functional/adapter/test_schema_drift.py
@@ -4,7 +4,7 @@ When a table already exists and --full-refresh is not set, the adapter should:
 - Skip re-creation if the table matches the model definition
 - Raise an error if there's column drift (name changes, additions, removals)
 - Raise an error if there's WITH options drift
-- Allow skipping drift detection with on_schema_change='ignore'
+- Allow skipping drift detection with on_schema_drift='ignore'
 """
 
 import pytest
@@ -476,12 +476,12 @@ class TestStreamingSourceOptionsDrift(ConfluentFixtures):
         assert_result_has_status(result, "my_source", "error")
 
 
-# -- on_schema_change='ignore' tests --
+# -- on_schema_drift='ignore' tests --
 
 TABLE_MODEL_IGNORE_DRIFT = """
 {{ config(
     materialized='table',
-    on_schema_change='ignore'
+    on_schema_drift='ignore'
 ) }}
 select order_id, price, order_time from {{ ref('source_for_drift') }}
 """
@@ -489,7 +489,7 @@ select order_id, price, order_time from {{ ref('source_for_drift') }}
 TABLE_MODEL_IGNORE_DRIFT_CHANGED = """
 {{ config(
     materialized='table',
-    on_schema_change='ignore'
+    on_schema_drift='ignore'
 ) }}
 select order_id, price from {{ ref('source_for_drift') }}
 """
@@ -498,7 +498,7 @@ STREAMING_TABLE_MODEL_IGNORE_DRIFT = """
 {{ config(
     materialized='streaming_table',
     with={'changelog.mode': 'upsert'},
-    on_schema_change='ignore'
+    on_schema_drift='ignore'
 ) }}
 select order_id, price, order_time from {{ ref('source_for_drift') }}
 """
@@ -507,14 +507,14 @@ STREAMING_TABLE_MODEL_IGNORE_DRIFT_CHANGED = """
 {{ config(
     materialized='streaming_table',
     with={'changelog.mode': 'append'},
-    on_schema_change='ignore'
+    on_schema_drift='ignore'
 ) }}
 select order_id, price from {{ ref('source_for_drift') }}
 """
 
 
 class TestIgnoreSchemaDrift(ConfluentFixtures):
-    """When on_schema_change='ignore', drift should not be detected or cause errors."""
+    """When on_schema_drift='ignore', drift should not be detected or cause errors."""
 
     @pytest.fixture(scope="class")
     def project_config_update(self, unique_schema):
@@ -528,6 +528,7 @@ class TestIgnoreSchemaDrift(ConfluentFixtures):
             "source_for_drift.sql": SOURCE_FOR_DRIFT,
             "my_table.sql": TABLE_MODEL_IGNORE_DRIFT,
             "my_streaming_table.sql": STREAMING_TABLE_MODEL_IGNORE_DRIFT,
+            "models.yml": STREAMING_TABLE_MODELS_YML,
         }
 
     @pytest.fixture(scope="class", autouse=True)
@@ -539,10 +540,10 @@ class TestIgnoreSchemaDrift(ConfluentFixtures):
         project.run_sql("drop table if exists my_streaming_table")
 
     def test_table_with_column_drift_ignored(self, project):
-        """With on_schema_change='ignore', column drift should not cause an error."""
+        """With on_schema_drift='ignore', column drift should not cause an error."""
         set_model_file(project, relation(project, "my_table"), TABLE_MODEL_IGNORE_DRIFT_CHANGED)
         result = run_dbt(["run"])
-        # Both models should succeed (skip)
+        # All models should succeed (skip)
         assert len(result) == 3  # source + my_table + my_streaming_table
         for r in result:
             assert r.status.name == "Success"
@@ -551,7 +552,7 @@ class TestIgnoreSchemaDrift(ConfluentFixtures):
         assert my_table_result.message == "SKIP"
 
     def test_streaming_table_with_options_drift_ignored(self, project):
-        """With on_schema_change='ignore', WITH options drift should not cause an error."""
+        """With on_schema_drift='ignore', WITH options drift should not cause an error."""
         set_model_file(
             project, relation(project, "my_streaming_table"), STREAMING_TABLE_MODEL_IGNORE_DRIFT_CHANGED
         )
@@ -566,7 +567,7 @@ class TestIgnoreSchemaDrift(ConfluentFixtures):
 
 
 class TestInvalidOnSchemaChange(ConfluentFixtures):
-    """Invalid on_schema_change values should raise a clear error."""
+    """Invalid on_schema_drift values should raise a clear error."""
 
     @pytest.fixture(scope="class")
     def project_config_update(self, unique_schema):
@@ -581,7 +582,7 @@ class TestInvalidOnSchemaChange(ConfluentFixtures):
             "my_table.sql": """
 {{ config(
     materialized='table',
-    on_schema_change='append_new_columns'
+    on_schema_drift='append_new_columns'
 ) }}
 select order_id, price, order_time from {{ ref('source_for_drift') }}
 """,
@@ -594,12 +595,12 @@ select order_id, price, order_time from {{ ref('source_for_drift') }}
         project.run_sql("drop table if exists source_for_drift")
         project.run_sql("drop table if exists my_table")
 
-    def test_invalid_on_schema_change_value(self, project):
-        """Invalid on_schema_change value should raise an error."""
+    def test_invalid_on_schema_drift_value(self, project):
+        """Invalid on_schema_drift value should raise an error."""
         result = run_dbt(["run"], expect_pass=False)
         my_table_result = get_result_by_name(result, "my_table")
         assert my_table_result is not None
         assert my_table_result.status.name == "Error"
-        assert "Invalid value for on_schema_change" in my_table_result.message
+        assert "Invalid value for on_schema_drift" in my_table_result.message
         assert "append_new_columns" in my_table_result.message
         assert "Expected 'ignore' or 'fail'" in my_table_result.message

--- a/tests/functional/adapter/test_schema_drift.py
+++ b/tests/functional/adapter/test_schema_drift.py
@@ -4,6 +4,7 @@ When a table already exists and --full-refresh is not set, the adapter should:
 - Skip re-creation if the table matches the model definition
 - Raise an error if there's column drift (name changes, additions, removals)
 - Raise an error if there's WITH options drift
+- Allow skipping drift detection with on_schema_change='ignore'
 """
 
 import pytest
@@ -473,3 +474,132 @@ class TestStreamingSourceOptionsDrift(ConfluentFixtures):
         set_model_file(project, relation(project, "my_source"), STREAMING_SOURCE_MODEL_TYPE_CHANGE)
         result = run_dbt(["run"], expect_pass=False)
         assert_result_has_status(result, "my_source", "error")
+
+
+# -- on_schema_change='ignore' tests --
+
+TABLE_MODEL_IGNORE_DRIFT = """
+{{ config(
+    materialized='table',
+    on_schema_change='ignore'
+) }}
+select order_id, price, order_time from {{ ref('source_for_drift') }}
+"""
+
+TABLE_MODEL_IGNORE_DRIFT_CHANGED = """
+{{ config(
+    materialized='table',
+    on_schema_change='ignore'
+) }}
+select order_id, price from {{ ref('source_for_drift') }}
+"""
+
+STREAMING_TABLE_MODEL_IGNORE_DRIFT = """
+{{ config(
+    materialized='streaming_table',
+    with={'changelog.mode': 'upsert'},
+    on_schema_change='ignore'
+) }}
+select order_id, price, order_time from {{ ref('source_for_drift') }}
+"""
+
+STREAMING_TABLE_MODEL_IGNORE_DRIFT_CHANGED = """
+{{ config(
+    materialized='streaming_table',
+    with={'changelog.mode': 'append'},
+    on_schema_change='ignore'
+) }}
+select order_id, price from {{ ref('source_for_drift') }}
+"""
+
+
+class TestIgnoreSchemaDrift(ConfluentFixtures):
+    """When on_schema_change='ignore', drift should not be detected or cause errors."""
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self, unique_schema):
+        return {
+            "models": {"+schema": unique_schema},
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "source_for_drift.sql": SOURCE_FOR_DRIFT,
+            "my_table.sql": TABLE_MODEL_IGNORE_DRIFT,
+            "my_streaming_table.sql": STREAMING_TABLE_MODEL_IGNORE_DRIFT,
+        }
+
+    @pytest.fixture(scope="class", autouse=True)
+    def setup_and_teardown(self, project):
+        run_dbt(["run", "--full-refresh"])
+        yield
+        project.run_sql("drop table if exists source_for_drift")
+        project.run_sql("drop table if exists my_table")
+        project.run_sql("drop table if exists my_streaming_table")
+
+    def test_table_with_column_drift_ignored(self, project):
+        """With on_schema_change='ignore', column drift should not cause an error."""
+        set_model_file(project, relation(project, "my_table"), TABLE_MODEL_IGNORE_DRIFT_CHANGED)
+        result = run_dbt(["run"])
+        # Both models should succeed (skip)
+        assert len(result) == 3  # source + my_table + my_streaming_table
+        for r in result:
+            assert r.status.name == "Success"
+        # my_table should have been skipped
+        my_table_result = get_result_by_name(result, "my_table")
+        assert my_table_result.message == "SKIP"
+
+    def test_streaming_table_with_options_drift_ignored(self, project):
+        """With on_schema_change='ignore', WITH options drift should not cause an error."""
+        set_model_file(
+            project, relation(project, "my_streaming_table"), STREAMING_TABLE_MODEL_IGNORE_DRIFT_CHANGED
+        )
+        result = run_dbt(["run"])
+        # All models should succeed (skip)
+        assert len(result) == 3
+        for r in result:
+            assert r.status.name == "Success"
+        # my_streaming_table should have been skipped
+        streaming_result = get_result_by_name(result, "my_streaming_table")
+        assert streaming_result.message == "SKIP"
+
+
+class TestInvalidOnSchemaChange(ConfluentFixtures):
+    """Invalid on_schema_change values should raise a clear error."""
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self, unique_schema):
+        return {
+            "models": {"+schema": unique_schema},
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "source_for_drift.sql": SOURCE_FOR_DRIFT,
+            "my_table.sql": """
+{{ config(
+    materialized='table',
+    on_schema_change='append_new_columns'
+) }}
+select order_id, price, order_time from {{ ref('source_for_drift') }}
+""",
+        }
+
+    @pytest.fixture(scope="class", autouse=True)
+    def setup_and_teardown(self, project):
+        run_dbt(["run", "--full-refresh"])
+        yield
+        project.run_sql("drop table if exists source_for_drift")
+        project.run_sql("drop table if exists my_table")
+
+    def test_invalid_on_schema_change_value(self, project):
+        """Invalid on_schema_change value should raise an error."""
+        result = run_dbt(["run"], expect_pass=False)
+        my_table_result = get_result_by_name(result, "my_table")
+        assert my_table_result is not None
+        assert my_table_result.status.name == "Error"
+        assert "Invalid value for on_schema_change" in my_table_result.message
+        assert "append_new_columns" in my_table_result.message
+        assert "Expected 'ignore' or 'fail'" in my_table_result.message

--- a/tests/functional/adapter/test_schema_drift.py
+++ b/tests/functional/adapter/test_schema_drift.py
@@ -15,6 +15,21 @@ from tests.functional.adapter.fixtures import ConfluentFixtures
 def relation(project, name):
     return project.adapter.Relation.create(identifier=name)
 
+
+def get_result_by_name(results, name):
+    """Extract a specific result by node name from run results."""
+    for result in results:
+        if result.node.name == name:
+            return result
+    return None
+
+
+def assert_result_has_status(results, name, expected_status):
+    """Assert that a specific result has the expected status."""
+    result = get_result_by_name(results, name)
+    assert result is not None, f"{name} not found in results"
+    assert result.status == expected_status, f"{name} expected status '{expected_status}' but got '{result.status}'"
+
 # -- Table (CTAS) models --
 
 TABLE_MODEL = """
@@ -42,6 +57,15 @@ TABLE_MODEL_REORDERED_COLUMNS = """
 select price, order_id, order_time from {{ ref('source_for_drift') }}
 """
 
+TABLE_MODEL_TYPE_CHANGE = """
+{{ config(materialized='table') }}
+select
+  cast(order_id as int) as order_id,
+  cast(price as decimal(10, 3)) as price,
+  order_time
+from {{ ref('source_for_drift') }}
+"""
+
 # -- Streaming table models --
 
 STREAMING_TABLE_MODEL = """
@@ -66,6 +90,18 @@ STREAMING_TABLE_MODEL_EXTRA_COLUMN = """
     with={'changelog.mode': 'upsert'},
 ) }}
 select order_id, price, order_time, order_id as duplicate_col from {{ ref('source_for_drift') }}
+"""
+
+STREAMING_TABLE_MODEL_TYPE_CHANGE = """
+{{ config(
+    materialized='streaming_table',
+    with={'changelog.mode': 'upsert'},
+) }}
+select
+  cast(order_id as int) as order_id,
+  price,
+  order_time
+from {{ ref('source_for_drift') }}
 """
 
 STREAMING_TABLE_MODELS_YML = """
@@ -128,6 +164,58 @@ STREAMING_SOURCE_MODEL_DIFFERENT_OPTIONS = """
 `value` STRING
 """
 
+STREAMING_SOURCE_MODEL_EXTRA_COLUMN = """
+{{ config(
+    materialized='streaming_source',
+    connector='faker',
+    with={
+        'rows-per-second': '1',
+        'number-of-rows': '100',
+    }
+) }}
+`id` BIGINT,
+`value` STRING,
+`extra_column` STRING
+"""
+
+STREAMING_SOURCE_MODEL_REMOVED_COLUMN = """
+{{ config(
+    materialized='streaming_source',
+    connector='faker',
+    with={
+        'rows-per-second': '1',
+        'number-of-rows': '100',
+    }
+) }}
+`id` BIGINT
+"""
+
+STREAMING_SOURCE_MODEL_RENAMED_COLUMN = """
+{{ config(
+    materialized='streaming_source',
+    connector='faker',
+    with={
+        'rows-per-second': '1',
+        'number-of-rows': '100',
+    }
+) }}
+`id` BIGINT,
+`name` STRING
+"""
+
+STREAMING_SOURCE_MODEL_TYPE_CHANGE = """
+{{ config(
+    materialized='streaming_source',
+    connector='faker',
+    with={
+        'rows-per-second': '1',
+        'number-of-rows': '100',
+    }
+) }}
+`id` INT,
+`value` STRING
+"""
+
 
 class TestTableIdempotent(ConfluentFixtures):
     """A table model should be idempotent: two consecutive runs without --full-refresh should succeed."""
@@ -158,6 +246,9 @@ class TestTableIdempotent(ConfluentFixtures):
         """Second run without --full-refresh should skip, not fail."""
         results = run_dbt(["run"])
         assert len(results) == 2
+        # Verify both models were skipped
+        for r in results:
+            assert r.message == "SKIP", f"{r.node.name} was not skipped (message: {r.message})"
 
 
 class TestTableColumnDrift(ConfluentFixtures):
@@ -189,17 +280,17 @@ class TestTableColumnDrift(ConfluentFixtures):
     def test_extra_column_detected(self, project):
         set_model_file(project, relation(project, "my_table"), TABLE_MODEL_EXTRA_COLUMN)
         result = run_dbt(["run"], expect_pass=False)
-        assert any(r.status == "error" for r in result)
+        assert_result_has_status(result, "my_table", "error")
 
     def test_removed_column_detected(self, project):
         set_model_file(project, relation(project, "my_table"), TABLE_MODEL_REMOVED_COLUMN)
         result = run_dbt(["run"], expect_pass=False)
-        assert any(r.status == "error" for r in result)
+        assert_result_has_status(result, "my_table", "error")
 
     def test_renamed_column_detected(self, project):
         set_model_file(project, relation(project, "my_table"), TABLE_MODEL_RENAMED_COLUMN)
         result = run_dbt(["run"], expect_pass=False)
-        assert any(r.status == "error" for r in result)
+        assert_result_has_status(result, "my_table", "error")
 
     def test_reordered_columns_not_detected(self, project):
         """Column reordering is not considered drift — order doesn't matter for Kafka tables."""
@@ -212,6 +303,13 @@ class TestTableColumnDrift(ConfluentFixtures):
         set_model_file(project, relation(project, "my_table"), TABLE_MODEL_EXTRA_COLUMN)
         result = run_dbt(["run", "--full-refresh"])
         assert len(result) == 2
+
+    @pytest.mark.skip("Data type drift detection not yet implemented")
+    def test_type_change_detected(self, project):
+        """Changing column data types should raise an error without --full-refresh."""
+        set_model_file(project, relation(project, "my_table"), TABLE_MODEL_TYPE_CHANGE)
+        result = run_dbt(["run"], expect_pass=False)
+        assert_result_has_status(result, "my_table", "error")
 
 
 class TestStreamingTableIdempotent(ConfluentFixtures):
@@ -242,6 +340,9 @@ class TestStreamingTableIdempotent(ConfluentFixtures):
     def test_second_run_skips(self, project):
         results = run_dbt(["run"])
         assert len(results) == 2
+        # Verify both models were skipped
+        for r in results:
+            assert r.message == "SKIP", f"{r.node.name} was not skipped (message: {r.message})"
 
 
 class TestStreamingTableOptionsDrift(ConfluentFixtures):
@@ -274,12 +375,19 @@ class TestStreamingTableOptionsDrift(ConfluentFixtures):
     def test_changed_options_detected(self, project):
         set_model_file(project, relation(project, "my_streaming_table"), STREAMING_TABLE_MODEL_DIFFERENT_OPTIONS)
         result = run_dbt(["run"], expect_pass=False)
-        assert any(r.status == "error" for r in result)
+        assert_result_has_status(result, "my_streaming_table", "error")
 
     def test_column_drift_detected(self, project):
         set_model_file(project, relation(project, "my_streaming_table"), STREAMING_TABLE_MODEL_EXTRA_COLUMN)
         result = run_dbt(["run"], expect_pass=False)
-        assert any(r.status == "error" for r in result)
+        assert_result_has_status(result, "my_streaming_table", "error")
+
+    @pytest.mark.skip("Data type drift detection not yet implemented")
+    def test_type_change_detected(self, project):
+        """Changing column data types should raise an error without --full-refresh."""
+        set_model_file(project, relation(project, "my_streaming_table"), STREAMING_TABLE_MODEL_TYPE_CHANGE)
+        result = run_dbt(["run"], expect_pass=False)
+        assert_result_has_status(result, "my_streaming_table", "error")
 
 
 class TestStreamingSourceIdempotent(ConfluentFixtures):
@@ -307,6 +415,8 @@ class TestStreamingSourceIdempotent(ConfluentFixtures):
     def test_second_run_skips(self, project):
         results = run_dbt(["run"])
         assert len(results) == 1
+        # Verify the model was skipped
+        assert results[0].message == "SKIP", f"{results[0].node.name} was not skipped (message: {results[0].message})"
 
 
 class TestStreamingSourceOptionsDrift(ConfluentFixtures):
@@ -334,4 +444,40 @@ class TestStreamingSourceOptionsDrift(ConfluentFixtures):
     def test_changed_options_detected(self, project):
         set_model_file(project, relation(project, "my_source"), STREAMING_SOURCE_MODEL_DIFFERENT_OPTIONS)
         result = run_dbt(["run"], expect_pass=False)
-        assert any(r.status == "error" for r in result)
+        assert_result_has_status(result, "my_source", "error")
+
+    def test_column_drift_not_detected(self, project):
+        """Column drift is not currently checked for streaming_source - only WITH options."""
+        set_model_file(project, relation(project, "my_source"), STREAMING_SOURCE_MODEL_EXTRA_COLUMN)
+        result = run_dbt(["run"])
+        # Should succeed (skip) even though columns changed
+        assert len(result) == 1
+        assert result[0].message == "SKIP", f"Expected skip but got: {result[0].message}"
+
+    @pytest.mark.skip("Column drift detection not yet implemented for streaming_source")
+    def test_extra_column_detected(self, project):
+        """Adding a column should raise an error without --full-refresh."""
+        set_model_file(project, relation(project, "my_source"), STREAMING_SOURCE_MODEL_EXTRA_COLUMN)
+        result = run_dbt(["run"], expect_pass=False)
+        assert_result_has_status(result, "my_source", "error")
+
+    @pytest.mark.skip("Column drift detection not yet implemented for streaming_source")
+    def test_removed_column_detected(self, project):
+        """Removing a column should raise an error without --full-refresh."""
+        set_model_file(project, relation(project, "my_source"), STREAMING_SOURCE_MODEL_REMOVED_COLUMN)
+        result = run_dbt(["run"], expect_pass=False)
+        assert_result_has_status(result, "my_source", "error")
+
+    @pytest.mark.skip("Column drift detection not yet implemented for streaming_source")
+    def test_renamed_column_detected(self, project):
+        """Renaming a column should raise an error without --full-refresh."""
+        set_model_file(project, relation(project, "my_source"), STREAMING_SOURCE_MODEL_RENAMED_COLUMN)
+        result = run_dbt(["run"], expect_pass=False)
+        assert_result_has_status(result, "my_source", "error")
+
+    @pytest.mark.skip("Data type drift detection not yet implemented for streaming_source")
+    def test_type_change_detected(self, project):
+        """Changing column data types should raise an error without --full-refresh."""
+        set_model_file(project, relation(project, "my_source"), STREAMING_SOURCE_MODEL_TYPE_CHANGE)
+        result = run_dbt(["run"], expect_pass=False)
+        assert_result_has_status(result, "my_source", "error")

--- a/tests/functional/adapter/test_schema_drift.py
+++ b/tests/functional/adapter/test_schema_drift.py
@@ -221,8 +221,17 @@ STREAMING_SOURCE_MODEL_TYPE_CHANGE = """
 """
 
 
-class TestTableIdempotent(ConfluentFixtures):
-    """A table model should be idempotent: two consecutive runs without --full-refresh should succeed."""
+# ---------------------------------------------------------------------------
+# Table (CTAS) drift tests
+# ---------------------------------------------------------------------------
+
+class TestTableSchemaDrift(ConfluentFixtures):
+    """Table schema drift detection tests.
+
+    Creates source_for_drift + my_table once, then runs drift checks against
+    the unchanged table.  Drift-error tests don't modify the table, so they
+    can all share the same class-scoped setup.
+    """
 
     @pytest.fixture(scope="class")
     def project_config_update(self, unique_schema):
@@ -240,7 +249,6 @@ class TestTableIdempotent(ConfluentFixtures):
 
     @pytest.fixture(scope="class", autouse=True)
     def setup_and_teardown(self, project):
-        # First run with --full-refresh to create everything
         run_dbt(["run", "--full-refresh"])
         yield
         project.run_sql("drop table if exists source_for_drift")
@@ -248,38 +256,11 @@ class TestTableIdempotent(ConfluentFixtures):
 
     def test_second_run_skips(self, project):
         """Second run without --full-refresh should skip, not fail."""
+        set_model_file(project, relation(project, "my_table"), TABLE_MODEL)
         results = run_dbt(["run"])
         assert len(results) == 2
-        # Verify both models were skipped
         for r in results:
             assert r.message == "SKIP", f"{r.node.name} was not skipped (message: {r.message})"
-
-
-class TestTableColumnDrift(ConfluentFixtures):
-    """Changing columns in a table model should raise an error without --full-refresh."""
-
-    @pytest.fixture(scope="class")
-    def project_config_update(self, unique_schema):
-        return {
-            "models": {"+schema": unique_schema},
-            "seeds": {"+schema": unique_schema},
-        }
-
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            "source_for_drift.sql": SOURCE_FOR_DRIFT,
-            "my_table.sql": TABLE_MODEL,
-        }
-
-    @pytest.fixture(autouse=True)
-    def setup_and_teardown(self, project):
-        # Reset model file before each test in case a previous test modified it
-        set_model_file(project, relation(project, "my_table"), TABLE_MODEL)
-        run_dbt(["run", "--full-refresh"])
-        yield
-        project.run_sql("drop table if exists source_for_drift")
-        project.run_sql("drop table if exists my_table")
 
     def test_extra_column_detected(self, project):
         set_model_file(project, relation(project, "my_table"), TABLE_MODEL_EXTRA_COLUMN)
@@ -301,18 +282,8 @@ class TestTableColumnDrift(ConfluentFixtures):
         set_model_file(project, relation(project, "my_table"), TABLE_MODEL_REORDERED_COLUMNS)
         result = run_dbt(["run"])
         assert len(result) == 2
-        # Verify both models were skipped (no drift detected)
         for r in result:
             assert r.message == "SKIP", f"{r.node.name} was not skipped (message: {r.message})"
-
-    def test_full_refresh_fixes_drift(self, project):
-        """After detecting drift, --full-refresh should succeed."""
-        set_model_file(project, relation(project, "my_table"), TABLE_MODEL_EXTRA_COLUMN)
-        result = run_dbt(["run", "--full-refresh"])
-        assert len(result) == 2
-        # Verify both models succeeded
-        for r in result:
-            assert r.status.name == "Success", f"{r.node.name} failed: {r.status}"
 
     def test_type_change_detected(self, project):
         """Changing column data types should raise an error without --full-refresh."""
@@ -321,8 +292,53 @@ class TestTableColumnDrift(ConfluentFixtures):
         assert_drift_error(result, "my_table")
 
 
-class TestStreamingTableIdempotent(ConfluentFixtures):
-    """A streaming_table model should be idempotent."""
+class TestTableFullRefreshFixesDrift(ConfluentFixtures):
+    """After detecting drift, --full-refresh should succeed.
+
+    Separated because --full-refresh recreates the table with a different
+    schema, which would invalidate other drift tests sharing the same setup.
+    """
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self, unique_schema):
+        return {
+            "models": {"+schema": unique_schema},
+            "seeds": {"+schema": unique_schema},
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "source_for_drift.sql": SOURCE_FOR_DRIFT,
+            "my_table.sql": TABLE_MODEL,
+        }
+
+    @pytest.fixture(scope="class", autouse=True)
+    def setup_and_teardown(self, project):
+        run_dbt(["run", "--full-refresh"])
+        yield
+        project.run_sql("drop table if exists source_for_drift")
+        project.run_sql("drop table if exists my_table")
+
+    def test_full_refresh_fixes_drift(self, project):
+        """After detecting drift, --full-refresh should succeed."""
+        set_model_file(project, relation(project, "my_table"), TABLE_MODEL_EXTRA_COLUMN)
+        result = run_dbt(["run", "--full-refresh"])
+        assert len(result) == 2
+        for r in result:
+            assert r.status.name == "Success", f"{r.node.name} failed: {r.status}"
+
+
+# ---------------------------------------------------------------------------
+# Streaming table drift tests
+# ---------------------------------------------------------------------------
+
+class TestStreamingTableSchemaDrift(ConfluentFixtures):
+    """Streaming table schema and options drift detection tests.
+
+    Creates source_for_drift + my_streaming_table once, then runs drift
+    checks.  Drift-error tests don't modify the table.
+    """
 
     @pytest.fixture(scope="class")
     def project_config_update(self, unique_schema):
@@ -347,39 +363,11 @@ class TestStreamingTableIdempotent(ConfluentFixtures):
         project.run_sql("drop table if exists my_streaming_table")
 
     def test_second_run_skips(self, project):
+        set_model_file(project, relation(project, "my_streaming_table"), STREAMING_TABLE_MODEL)
         results = run_dbt(["run"])
         assert len(results) == 2
-        # Verify both models were skipped
         for r in results:
             assert r.message == "SKIP", f"{r.node.name} was not skipped (message: {r.message})"
-
-
-class TestStreamingTableOptionsDrift(ConfluentFixtures):
-    """Changing WITH options in a streaming_table should raise an error."""
-
-    @pytest.fixture(scope="class")
-    def project_config_update(self, unique_schema):
-        return {
-            "models": {"+schema": unique_schema},
-            "seeds": {"+schema": unique_schema},
-        }
-
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            "source_for_drift.sql": SOURCE_FOR_DRIFT,
-            "my_streaming_table.sql": STREAMING_TABLE_MODEL,
-            "models.yml": STREAMING_TABLE_MODELS_YML,
-        }
-
-    @pytest.fixture(autouse=True)
-    def setup_and_teardown(self, project):
-        # Reset model file before each test in case a previous test modified it
-        set_model_file(project, relation(project, "my_streaming_table"), STREAMING_TABLE_MODEL)
-        run_dbt(["run", "--full-refresh"])
-        yield
-        project.run_sql("drop table if exists source_for_drift")
-        project.run_sql("drop table if exists my_streaming_table")
 
     def test_changed_options_detected(self, project):
         set_model_file(project, relation(project, "my_streaming_table"), STREAMING_TABLE_MODEL_DIFFERENT_OPTIONS)
@@ -398,8 +386,16 @@ class TestStreamingTableOptionsDrift(ConfluentFixtures):
         assert_drift_error(result, "my_streaming_table")
 
 
-class TestStreamingSourceIdempotent(ConfluentFixtures):
-    """A streaming_source model should be idempotent."""
+# ---------------------------------------------------------------------------
+# Streaming source drift tests
+# ---------------------------------------------------------------------------
+
+class TestStreamingSourceSchemaDrift(ConfluentFixtures):
+    """Streaming source schema and options drift detection tests.
+
+    Creates my_source once, then runs drift checks.  Drift-error tests
+    don't modify the table.
+    """
 
     @pytest.fixture(scope="class")
     def project_config_update(self, unique_schema):
@@ -421,33 +417,10 @@ class TestStreamingSourceIdempotent(ConfluentFixtures):
         project.run_sql("drop table if exists my_source")
 
     def test_second_run_skips(self, project):
+        set_model_file(project, relation(project, "my_source"), STREAMING_SOURCE_MODEL)
         results = run_dbt(["run"])
         assert len(results) == 1
-        # Verify the model was skipped
         assert results[0].message == "SKIP", f"{results[0].node.name} was not skipped (message: {results[0].message})"
-
-
-class TestStreamingSourceOptionsDrift(ConfluentFixtures):
-    """Changing WITH options or columns in a streaming_source should raise an error."""
-
-    @pytest.fixture(scope="class")
-    def project_config_update(self, unique_schema):
-        return {
-            "models": {"+schema": unique_schema},
-            "seeds": {"+schema": unique_schema},
-        }
-
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            "my_source.sql": STREAMING_SOURCE_MODEL,
-        }
-
-    @pytest.fixture(autouse=True)
-    def setup_and_teardown(self, project):
-        run_dbt(["run", "--full-refresh"])
-        yield
-        project.run_sql("drop table if exists my_source")
 
     def test_changed_options_detected(self, project):
         set_model_file(project, relation(project, "my_source"), STREAMING_SOURCE_MODEL_DIFFERENT_OPTIONS)
@@ -479,7 +452,9 @@ class TestStreamingSourceOptionsDrift(ConfluentFixtures):
         assert_drift_error(result, "my_source")
 
 
-# -- on_schema_drift='ignore' tests --
+# ---------------------------------------------------------------------------
+# on_schema_drift='ignore' tests
+# ---------------------------------------------------------------------------
 
 TABLE_MODEL_IGNORE_DRIFT = """
 {{ config(

--- a/tests/functional/adapter/test_schema_drift.py
+++ b/tests/functional/adapter/test_schema_drift.py
@@ -1,0 +1,337 @@
+"""Tests for schema drift detection.
+
+When a table already exists and --full-refresh is not set, the adapter should:
+- Skip re-creation if the table matches the model definition
+- Raise an error if there's column drift (name changes, additions, removals)
+- Raise an error if there's WITH options drift
+"""
+
+import pytest
+
+from dbt.tests.util import run_dbt, set_model_file
+from tests.functional.adapter.fixtures import ConfluentFixtures
+
+
+def relation(project, name):
+    return project.adapter.Relation.create(identifier=name)
+
+# -- Table (CTAS) models --
+
+TABLE_MODEL = """
+{{ config(materialized='table') }}
+select order_id, price, order_time from {{ ref('source_for_drift') }}
+"""
+
+TABLE_MODEL_EXTRA_COLUMN = """
+{{ config(materialized='table') }}
+select order_id, price, order_time, order_id as duplicate_col from {{ ref('source_for_drift') }}
+"""
+
+TABLE_MODEL_REMOVED_COLUMN = """
+{{ config(materialized='table') }}
+select order_id, price from {{ ref('source_for_drift') }}
+"""
+
+TABLE_MODEL_RENAMED_COLUMN = """
+{{ config(materialized='table') }}
+select order_id as id, price, order_time from {{ ref('source_for_drift') }}
+"""
+
+TABLE_MODEL_REORDERED_COLUMNS = """
+{{ config(materialized='table') }}
+select price, order_id, order_time from {{ ref('source_for_drift') }}
+"""
+
+# -- Streaming table models --
+
+STREAMING_TABLE_MODEL = """
+{{ config(
+    materialized='streaming_table',
+    with={'changelog.mode': 'upsert'},
+) }}
+select order_id, price, order_time from {{ ref('source_for_drift') }}
+"""
+
+STREAMING_TABLE_MODEL_DIFFERENT_OPTIONS = """
+{{ config(
+    materialized='streaming_table',
+    with={'changelog.mode': 'append'},
+) }}
+select order_id, price, order_time from {{ ref('source_for_drift') }}
+"""
+
+STREAMING_TABLE_MODEL_EXTRA_COLUMN = """
+{{ config(
+    materialized='streaming_table',
+    with={'changelog.mode': 'upsert'},
+) }}
+select order_id, price, order_time, order_id as duplicate_col from {{ ref('source_for_drift') }}
+"""
+
+STREAMING_TABLE_MODELS_YML = """
+models:
+  - name: my_streaming_table
+    columns:
+      - name: order_id
+        data_type: bigint
+        constraints:
+          - type: not_null
+          - type: primary_key
+            expression: "not enforced"
+      - name: price
+        data_type: decimal(10,2)
+      - name: order_time
+        data_type: timestamp(3)
+"""
+
+# -- Streaming source models --
+
+SOURCE_FOR_DRIFT = """
+{{ config(
+    materialized='streaming_source',
+    connector='faker',
+    with={
+        'rows-per-second': '1',
+        'number-of-rows': '100',
+    }
+) }}
+`order_id` BIGINT,
+`price` DECIMAL(10, 2),
+`order_time` TIMESTAMP(3),
+WATERMARK FOR order_time AS order_time - INTERVAL '5' SECOND,
+PRIMARY KEY(`order_id`) NOT ENFORCED
+"""
+
+STREAMING_SOURCE_MODEL = """
+{{ config(
+    materialized='streaming_source',
+    connector='faker',
+    with={
+        'rows-per-second': '1',
+        'number-of-rows': '100',
+    }
+) }}
+`id` BIGINT,
+`value` STRING
+"""
+
+STREAMING_SOURCE_MODEL_DIFFERENT_OPTIONS = """
+{{ config(
+    materialized='streaming_source',
+    connector='faker',
+    with={
+        'rows-per-second': '10',
+        'number-of-rows': '100',
+    }
+) }}
+`id` BIGINT,
+`value` STRING
+"""
+
+
+class TestTableIdempotent(ConfluentFixtures):
+    """A table model should be idempotent: two consecutive runs without --full-refresh should succeed."""
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self, unique_schema):
+        return {
+            "models": {"+schema": unique_schema},
+            "seeds": {"+schema": unique_schema},
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "source_for_drift.sql": SOURCE_FOR_DRIFT,
+            "my_table.sql": TABLE_MODEL,
+        }
+
+    @pytest.fixture(scope="class", autouse=True)
+    def setup_and_teardown(self, project):
+        # First run with --full-refresh to create everything
+        run_dbt(["run", "--full-refresh"])
+        yield
+        project.run_sql("drop table if exists source_for_drift")
+        project.run_sql("drop table if exists my_table")
+
+    def test_second_run_skips(self, project):
+        """Second run without --full-refresh should skip, not fail."""
+        results = run_dbt(["run"])
+        assert len(results) == 2
+
+
+class TestTableColumnDrift(ConfluentFixtures):
+    """Changing columns in a table model should raise an error without --full-refresh."""
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self, unique_schema):
+        return {
+            "models": {"+schema": unique_schema},
+            "seeds": {"+schema": unique_schema},
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "source_for_drift.sql": SOURCE_FOR_DRIFT,
+            "my_table.sql": TABLE_MODEL,
+        }
+
+    @pytest.fixture(autouse=True)
+    def setup_and_teardown(self, project):
+        # Reset model file before each test in case a previous test modified it
+        set_model_file(project, relation(project, "my_table"), TABLE_MODEL)
+        run_dbt(["run", "--full-refresh"])
+        yield
+        project.run_sql("drop table if exists source_for_drift")
+        project.run_sql("drop table if exists my_table")
+
+    def test_extra_column_detected(self, project):
+        set_model_file(project, relation(project, "my_table"), TABLE_MODEL_EXTRA_COLUMN)
+        result = run_dbt(["run"], expect_pass=False)
+        assert any(r.status == "error" for r in result)
+
+    def test_removed_column_detected(self, project):
+        set_model_file(project, relation(project, "my_table"), TABLE_MODEL_REMOVED_COLUMN)
+        result = run_dbt(["run"], expect_pass=False)
+        assert any(r.status == "error" for r in result)
+
+    def test_renamed_column_detected(self, project):
+        set_model_file(project, relation(project, "my_table"), TABLE_MODEL_RENAMED_COLUMN)
+        result = run_dbt(["run"], expect_pass=False)
+        assert any(r.status == "error" for r in result)
+
+    def test_reordered_columns_not_detected(self, project):
+        """Column reordering is not considered drift — order doesn't matter for Kafka tables."""
+        set_model_file(project, relation(project, "my_table"), TABLE_MODEL_REORDERED_COLUMNS)
+        result = run_dbt(["run"])
+        assert len(result) == 2
+
+    def test_full_refresh_fixes_drift(self, project):
+        """After detecting drift, --full-refresh should succeed."""
+        set_model_file(project, relation(project, "my_table"), TABLE_MODEL_EXTRA_COLUMN)
+        result = run_dbt(["run", "--full-refresh"])
+        assert len(result) == 2
+
+
+class TestStreamingTableIdempotent(ConfluentFixtures):
+    """A streaming_table model should be idempotent."""
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self, unique_schema):
+        return {
+            "models": {"+schema": unique_schema},
+            "seeds": {"+schema": unique_schema},
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "source_for_drift.sql": SOURCE_FOR_DRIFT,
+            "my_streaming_table.sql": STREAMING_TABLE_MODEL,
+            "models.yml": STREAMING_TABLE_MODELS_YML,
+        }
+
+    @pytest.fixture(scope="class", autouse=True)
+    def setup_and_teardown(self, project):
+        run_dbt(["run", "--full-refresh"])
+        yield
+        project.run_sql("drop table if exists source_for_drift")
+        project.run_sql("drop table if exists my_streaming_table")
+
+    def test_second_run_skips(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 2
+
+
+class TestStreamingTableOptionsDrift(ConfluentFixtures):
+    """Changing WITH options in a streaming_table should raise an error."""
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self, unique_schema):
+        return {
+            "models": {"+schema": unique_schema},
+            "seeds": {"+schema": unique_schema},
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "source_for_drift.sql": SOURCE_FOR_DRIFT,
+            "my_streaming_table.sql": STREAMING_TABLE_MODEL,
+            "models.yml": STREAMING_TABLE_MODELS_YML,
+        }
+
+    @pytest.fixture(autouse=True)
+    def setup_and_teardown(self, project):
+        # Reset model file before each test in case a previous test modified it
+        set_model_file(project, relation(project, "my_streaming_table"), STREAMING_TABLE_MODEL)
+        run_dbt(["run", "--full-refresh"])
+        yield
+        project.run_sql("drop table if exists source_for_drift")
+        project.run_sql("drop table if exists my_streaming_table")
+
+    def test_changed_options_detected(self, project):
+        set_model_file(project, relation(project, "my_streaming_table"), STREAMING_TABLE_MODEL_DIFFERENT_OPTIONS)
+        result = run_dbt(["run"], expect_pass=False)
+        assert any(r.status == "error" for r in result)
+
+    def test_column_drift_detected(self, project):
+        set_model_file(project, relation(project, "my_streaming_table"), STREAMING_TABLE_MODEL_EXTRA_COLUMN)
+        result = run_dbt(["run"], expect_pass=False)
+        assert any(r.status == "error" for r in result)
+
+
+class TestStreamingSourceIdempotent(ConfluentFixtures):
+    """A streaming_source model should be idempotent."""
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self, unique_schema):
+        return {
+            "models": {"+schema": unique_schema},
+            "seeds": {"+schema": unique_schema},
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_source.sql": STREAMING_SOURCE_MODEL,
+        }
+
+    @pytest.fixture(scope="class", autouse=True)
+    def setup_and_teardown(self, project):
+        run_dbt(["run", "--full-refresh"])
+        yield
+        project.run_sql("drop table if exists my_source")
+
+    def test_second_run_skips(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+
+
+class TestStreamingSourceOptionsDrift(ConfluentFixtures):
+    """Changing WITH options in a streaming_source should raise an error."""
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self, unique_schema):
+        return {
+            "models": {"+schema": unique_schema},
+            "seeds": {"+schema": unique_schema},
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_source.sql": STREAMING_SOURCE_MODEL,
+        }
+
+    @pytest.fixture(autouse=True)
+    def setup_and_teardown(self, project):
+        run_dbt(["run", "--full-refresh"])
+        yield
+        project.run_sql("drop table if exists my_source")
+
+    def test_changed_options_detected(self, project):
+        set_model_file(project, relation(project, "my_source"), STREAMING_SOURCE_MODEL_DIFFERENT_OPTIONS)
+        result = run_dbt(["run"], expect_pass=False)
+        assert any(r.status == "error" for r in result)

--- a/tests/functional/adapter/test_schema_drift.py
+++ b/tests/functional/adapter/test_schema_drift.py
@@ -297,14 +297,19 @@ class TestTableColumnDrift(ConfluentFixtures):
         set_model_file(project, relation(project, "my_table"), TABLE_MODEL_REORDERED_COLUMNS)
         result = run_dbt(["run"])
         assert len(result) == 2
+        # Verify both models were skipped (no drift detected)
+        for r in result:
+            assert r.message == "SKIP", f"{r.node.name} was not skipped (message: {r.message})"
 
     def test_full_refresh_fixes_drift(self, project):
         """After detecting drift, --full-refresh should succeed."""
         set_model_file(project, relation(project, "my_table"), TABLE_MODEL_EXTRA_COLUMN)
         result = run_dbt(["run", "--full-refresh"])
         assert len(result) == 2
+        # Verify both models succeeded
+        for r in result:
+            assert r.status.name == "Success", f"{r.node.name} failed: {r.status}"
 
-    @pytest.mark.skip("Data type drift detection not yet implemented")
     def test_type_change_detected(self, project):
         """Changing column data types should raise an error without --full-refresh."""
         set_model_file(project, relation(project, "my_table"), TABLE_MODEL_TYPE_CHANGE)
@@ -382,7 +387,6 @@ class TestStreamingTableOptionsDrift(ConfluentFixtures):
         result = run_dbt(["run"], expect_pass=False)
         assert_result_has_status(result, "my_streaming_table", "error")
 
-    @pytest.mark.skip("Data type drift detection not yet implemented")
     def test_type_change_detected(self, project):
         """Changing column data types should raise an error without --full-refresh."""
         set_model_file(project, relation(project, "my_streaming_table"), STREAMING_TABLE_MODEL_TYPE_CHANGE)
@@ -420,7 +424,7 @@ class TestStreamingSourceIdempotent(ConfluentFixtures):
 
 
 class TestStreamingSourceOptionsDrift(ConfluentFixtures):
-    """Changing WITH options in a streaming_source should raise an error."""
+    """Changing WITH options or columns in a streaming_source should raise an error."""
 
     @pytest.fixture(scope="class")
     def project_config_update(self, unique_schema):
@@ -446,36 +450,24 @@ class TestStreamingSourceOptionsDrift(ConfluentFixtures):
         result = run_dbt(["run"], expect_pass=False)
         assert_result_has_status(result, "my_source", "error")
 
-    def test_column_drift_not_detected(self, project):
-        """Column drift is not currently checked for streaming_source - only WITH options."""
-        set_model_file(project, relation(project, "my_source"), STREAMING_SOURCE_MODEL_EXTRA_COLUMN)
-        result = run_dbt(["run"])
-        # Should succeed (skip) even though columns changed
-        assert len(result) == 1
-        assert result[0].message == "SKIP", f"Expected skip but got: {result[0].message}"
-
-    @pytest.mark.skip("Column drift detection not yet implemented for streaming_source")
     def test_extra_column_detected(self, project):
         """Adding a column should raise an error without --full-refresh."""
         set_model_file(project, relation(project, "my_source"), STREAMING_SOURCE_MODEL_EXTRA_COLUMN)
         result = run_dbt(["run"], expect_pass=False)
         assert_result_has_status(result, "my_source", "error")
 
-    @pytest.mark.skip("Column drift detection not yet implemented for streaming_source")
     def test_removed_column_detected(self, project):
         """Removing a column should raise an error without --full-refresh."""
         set_model_file(project, relation(project, "my_source"), STREAMING_SOURCE_MODEL_REMOVED_COLUMN)
         result = run_dbt(["run"], expect_pass=False)
         assert_result_has_status(result, "my_source", "error")
 
-    @pytest.mark.skip("Column drift detection not yet implemented for streaming_source")
     def test_renamed_column_detected(self, project):
         """Renaming a column should raise an error without --full-refresh."""
         set_model_file(project, relation(project, "my_source"), STREAMING_SOURCE_MODEL_RENAMED_COLUMN)
         result = run_dbt(["run"], expect_pass=False)
         assert_result_has_status(result, "my_source", "error")
 
-    @pytest.mark.skip("Data type drift detection not yet implemented for streaming_source")
     def test_type_change_detected(self, project):
         """Changing column data types should raise an error without --full-refresh."""
         set_model_file(project, relation(project, "my_source"), STREAMING_SOURCE_MODEL_TYPE_CHANGE)

--- a/tests/functional/adapter/test_schema_drift.py
+++ b/tests/functional/adapter/test_schema_drift.py
@@ -29,10 +29,13 @@ def assert_drift_error(results, name):
     """Assert that a specific result failed with a drift detection error."""
     result = get_result_by_name(results, name)
     assert result is not None, f"{name} not found in results"
-    assert result.status == "error", f"{name} expected status 'error' but got '{result.status}'"
+    assert result.status.name == "Error", (
+        f"{name} expected status 'Error' but got '{result.status.name}'"
+    )
     assert "drift detected" in result.message.lower(), (
         f"{name} error was not a drift error: {result.message}"
     )
+
 
 # -- Table (CTAS) models --
 
@@ -225,6 +228,7 @@ STREAMING_SOURCE_MODEL_TYPE_CHANGE = """
 # Table (CTAS) drift tests
 # ---------------------------------------------------------------------------
 
+
 class TestTableSchemaDrift(ConfluentFixtures):
     """Table schema drift detection tests.
 
@@ -333,6 +337,7 @@ class TestTableFullRefreshFixesDrift(ConfluentFixtures):
 # Streaming table drift tests
 # ---------------------------------------------------------------------------
 
+
 class TestStreamingTableSchemaDrift(ConfluentFixtures):
     """Streaming table schema and options drift detection tests.
 
@@ -370,18 +375,26 @@ class TestStreamingTableSchemaDrift(ConfluentFixtures):
             assert r.message == "SKIP", f"{r.node.name} was not skipped (message: {r.message})"
 
     def test_changed_options_detected(self, project):
-        set_model_file(project, relation(project, "my_streaming_table"), STREAMING_TABLE_MODEL_DIFFERENT_OPTIONS)
+        set_model_file(
+            project,
+            relation(project, "my_streaming_table"),
+            STREAMING_TABLE_MODEL_DIFFERENT_OPTIONS,
+        )
         result = run_dbt(["run"], expect_pass=False)
         assert_drift_error(result, "my_streaming_table")
 
     def test_column_drift_detected(self, project):
-        set_model_file(project, relation(project, "my_streaming_table"), STREAMING_TABLE_MODEL_EXTRA_COLUMN)
+        set_model_file(
+            project, relation(project, "my_streaming_table"), STREAMING_TABLE_MODEL_EXTRA_COLUMN
+        )
         result = run_dbt(["run"], expect_pass=False)
         assert_drift_error(result, "my_streaming_table")
 
     def test_type_change_detected(self, project):
         """Changing column data types should raise an error without --full-refresh."""
-        set_model_file(project, relation(project, "my_streaming_table"), STREAMING_TABLE_MODEL_TYPE_CHANGE)
+        set_model_file(
+            project, relation(project, "my_streaming_table"), STREAMING_TABLE_MODEL_TYPE_CHANGE
+        )
         result = run_dbt(["run"], expect_pass=False)
         assert_drift_error(result, "my_streaming_table")
 
@@ -389,6 +402,7 @@ class TestStreamingTableSchemaDrift(ConfluentFixtures):
 # ---------------------------------------------------------------------------
 # Streaming source drift tests
 # ---------------------------------------------------------------------------
+
 
 class TestStreamingSourceSchemaDrift(ConfluentFixtures):
     """Streaming source schema and options drift detection tests.
@@ -420,28 +434,38 @@ class TestStreamingSourceSchemaDrift(ConfluentFixtures):
         set_model_file(project, relation(project, "my_source"), STREAMING_SOURCE_MODEL)
         results = run_dbt(["run"])
         assert len(results) == 1
-        assert results[0].message == "SKIP", f"{results[0].node.name} was not skipped (message: {results[0].message})"
+        assert results[0].message == "SKIP", (
+            f"{results[0].node.name} was not skipped (message: {results[0].message})"
+        )
 
     def test_changed_options_detected(self, project):
-        set_model_file(project, relation(project, "my_source"), STREAMING_SOURCE_MODEL_DIFFERENT_OPTIONS)
+        set_model_file(
+            project, relation(project, "my_source"), STREAMING_SOURCE_MODEL_DIFFERENT_OPTIONS
+        )
         result = run_dbt(["run"], expect_pass=False)
         assert_drift_error(result, "my_source")
 
     def test_extra_column_detected(self, project):
         """Adding a column should raise an error without --full-refresh."""
-        set_model_file(project, relation(project, "my_source"), STREAMING_SOURCE_MODEL_EXTRA_COLUMN)
+        set_model_file(
+            project, relation(project, "my_source"), STREAMING_SOURCE_MODEL_EXTRA_COLUMN
+        )
         result = run_dbt(["run"], expect_pass=False)
         assert_drift_error(result, "my_source")
 
     def test_removed_column_detected(self, project):
         """Removing a column should raise an error without --full-refresh."""
-        set_model_file(project, relation(project, "my_source"), STREAMING_SOURCE_MODEL_REMOVED_COLUMN)
+        set_model_file(
+            project, relation(project, "my_source"), STREAMING_SOURCE_MODEL_REMOVED_COLUMN
+        )
         result = run_dbt(["run"], expect_pass=False)
         assert_drift_error(result, "my_source")
 
     def test_renamed_column_detected(self, project):
         """Renaming a column should raise an error without --full-refresh."""
-        set_model_file(project, relation(project, "my_source"), STREAMING_SOURCE_MODEL_RENAMED_COLUMN)
+        set_model_file(
+            project, relation(project, "my_source"), STREAMING_SOURCE_MODEL_RENAMED_COLUMN
+        )
         result = run_dbt(["run"], expect_pass=False)
         assert_drift_error(result, "my_source")
 
@@ -532,7 +556,9 @@ class TestIgnoreSchemaDrift(ConfluentFixtures):
     def test_streaming_table_with_options_drift_ignored(self, project):
         """With on_schema_drift='ignore', WITH options drift should not cause an error."""
         set_model_file(
-            project, relation(project, "my_streaming_table"), STREAMING_TABLE_MODEL_IGNORE_DRIFT_CHANGED
+            project,
+            relation(project, "my_streaming_table"),
+            STREAMING_TABLE_MODEL_IGNORE_DRIFT_CHANGED,
         )
         result = run_dbt(["run"])
         # All models should succeed (skip)

--- a/tests/functional/adapter/test_unit_materialization.py
+++ b/tests/functional/adapter/test_unit_materialization.py
@@ -4,7 +4,6 @@ import pytest
 
 from dbt.adapters.base.relation import BaseRelation
 from dbt.adapters.contracts.relation import RelationType
-from dbt.tests.adapter.materialized_view import files
 from dbt.tests.util import (
     assert_message_in_logs,
     get_model_file,

--- a/tests/unit/test_check_schema_drift.py
+++ b/tests/unit/test_check_schema_drift.py
@@ -7,42 +7,9 @@ from dbt_common.exceptions import CompilationError
 from dbt.adapters.confluent.impl import ConfluentAdapter
 
 # ---------------------------------------------------------------------------
-# _normalize_type
-# ---------------------------------------------------------------------------
-
-class TestNormalizeType:
-    def test_simple_type(self):
-        assert ConfluentAdapter._normalize_type("bigint") == "BIGINT"
-
-    def test_parameterized_type(self):
-        assert ConfluentAdapter._normalize_type("DECIMAL(10, 2)") == "DECIMAL(10, 2)"
-
-    def test_no_space_after_comma(self):
-        assert ConfluentAdapter._normalize_type("DECIMAL(10,2)") == "DECIMAL(10, 2)"
-
-    def test_extra_spaces(self):
-        assert ConfluentAdapter._normalize_type("  decimal( 10 , 2 )  ") == "DECIMAL(10, 2)"
-
-    def test_timestamp_precision(self):
-        assert ConfluentAdapter._normalize_type("timestamp(3)") == "TIMESTAMP(3)"
-
-    def test_collapses_internal_whitespace(self):
-        assert ConfluentAdapter._normalize_type("DOUBLE   PRECISION") == "DOUBLE PRECISION"
-
-    def test_array_angle_brackets(self):
-        assert ConfluentAdapter._normalize_type("ARRAY< INT >") == "ARRAY<INT>"
-
-    def test_map_angle_brackets(self):
-        assert ConfluentAdapter._normalize_type("map< string,int >") == "MAP<STRING, INT>"
-
-    def test_row_angle_brackets(self):
-        assert ConfluentAdapter._normalize_type("ROW< name STRING, age INT >") == "ROW<NAME STRING, AGE INT>"
-
-
-
-# ---------------------------------------------------------------------------
 # check_schema_drift
 # ---------------------------------------------------------------------------
+
 
 def _make_agate_table(rows):
     """Create an agate.Table with column_name and data_type columns."""
@@ -99,22 +66,23 @@ class TestCheckSchemaDrift:
         expected = _make_agate_table([("b", "STRING"), ("a", "BIGINT")])
         adapter.check_schema_drift("t", existing, expected, {}, {})
 
-    def test_case_insensitive_names(self, adapter):
+    def test_case_sensitive_names(self, adapter):
+        """Flink allows distinct columns differing only by case (when backtick-quoted).
+        Both sides come from INFORMATION_SCHEMA which preserves declared casing,
+        so a case difference is real drift."""
         existing = _make_agate_table([("ID", "BIGINT")])
         expected = _make_agate_table([("id", "BIGINT")])
-        adapter.check_schema_drift("t", existing, expected, {}, {})
-
-    def test_type_normalization(self, adapter):
-        existing = _make_agate_table([("price", "DECIMAL(10, 2)")])
-        expected = [{"column_name": "price", "data_type": "decimal(10,2)"}]
-        adapter.check_schema_drift("t", existing, expected, {}, {})
+        with pytest.raises(CompilationError, match="drift detected"):
+            adapter.check_schema_drift("t", existing, expected, {}, {})
 
     def test_options_drift_detected(self, adapter):
         existing = _make_agate_table([("id", "BIGINT")])
         expected = _make_agate_table([("id", "BIGINT")])
         with pytest.raises(CompilationError, match="drift detected"):
             adapter.check_schema_drift(
-                "t", existing, expected,
+                "t",
+                existing,
+                expected,
                 expected_with={"changelog.mode": "append"},
                 existing_options={"changelog.mode": "upsert"},
             )
@@ -124,7 +92,9 @@ class TestCheckSchemaDrift:
         expected = _make_agate_table([("id", "BIGINT")])
         with pytest.raises(CompilationError, match="drift detected"):
             adapter.check_schema_drift(
-                "t", existing, expected,
+                "t",
+                existing,
+                expected,
                 expected_with={"changelog.mode": "append"},
                 existing_options={},
             )
@@ -134,7 +104,9 @@ class TestCheckSchemaDrift:
         existing = _make_agate_table([("id", "BIGINT")])
         expected = _make_agate_table([("id", "BIGINT")])
         adapter.check_schema_drift(
-            "t", existing, expected,
+            "t",
+            existing,
+            expected,
             expected_with={"changelog.mode": "upsert"},
             existing_options={"changelog.mode": "upsert", "connector": "faker"},
         )
@@ -144,7 +116,22 @@ class TestCheckSchemaDrift:
         existing = _make_agate_table([("id", "BIGINT")])
         expected = _make_agate_table([("id", "BIGINT")])
         adapter.check_schema_drift(
-            "t", existing, expected,
+            "t",
+            existing,
+            expected,
             expected_with={},
             existing_options={"anything": "here"},
+        )
+
+    def test_options_non_string_value_coerced(self, adapter):
+        """Config values (int, bool) are coerced to str before comparing with I_S strings."""
+        existing = _make_agate_table([("id", "BIGINT")])
+        expected = _make_agate_table([("id", "BIGINT")])
+        # No drift: int 1 should match string "1"
+        adapter.check_schema_drift(
+            "t",
+            existing,
+            expected,
+            expected_with={"rows-per-second": 1},
+            existing_options={"rows-per-second": "1"},
         )

--- a/tests/unit/test_schema_drift.py
+++ b/tests/unit/test_schema_drift.py
@@ -27,7 +27,7 @@ class TestNormalizeType:
         assert ConfluentAdapter._normalize_type("timestamp(3)") == "TIMESTAMP(3)"
 
     def test_collapses_internal_whitespace(self):
-        assert ConfluentAdapter._normalize_type("DOUBLE   PRECISION") == "DOUBLE"
+        assert ConfluentAdapter._normalize_type("DOUBLE   PRECISION") == "DOUBLE PRECISION"
 
     def test_array_angle_brackets(self):
         assert ConfluentAdapter._normalize_type("ARRAY< INT >") == "ARRAY<INT>"
@@ -38,122 +38,6 @@ class TestNormalizeType:
     def test_row_angle_brackets(self):
         assert ConfluentAdapter._normalize_type("ROW< name STRING, age INT >") == "ROW<NAME STRING, AGE INT>"
 
-    def test_alias_string(self):
-        assert ConfluentAdapter._normalize_type("STRING") == "VARCHAR(2147483647)"
-
-    def test_alias_bytes(self):
-        assert ConfluentAdapter._normalize_type("BYTES") == "VARBINARY(2147483647)"
-
-    def test_alias_integer(self):
-        assert ConfluentAdapter._normalize_type("INTEGER") == "INT"
-
-    def test_alias_double_precision(self):
-        assert ConfluentAdapter._normalize_type("DOUBLE PRECISION") == "DOUBLE"
-
-    def test_alias_not_applied_to_parameterized(self):
-        """STRING alias should only match the bare keyword, not VARCHAR(n)."""
-        assert ConfluentAdapter._normalize_type("VARCHAR(100)") == "VARCHAR(100)"
-
-
-# ---------------------------------------------------------------------------
-# parse_column_definitions
-# ---------------------------------------------------------------------------
-
-class TestParseColumnDefinitions:
-    """Test the SQL column definition parser."""
-
-    @pytest.fixture
-    def adapter(self):
-        """Minimal adapter instance — only need the method, not a real connection."""
-        return ConfluentAdapter.__new__(ConfluentAdapter)
-
-    def test_basic_columns(self, adapter):
-        sql = "`id` BIGINT,\n`value` STRING"
-        result = adapter.parse_column_definitions(sql)
-        assert result == [
-            {"column_name": "id", "data_type": "BIGINT"},
-            {"column_name": "value", "data_type": "VARCHAR(2147483647)"},
-        ]
-
-    def test_parameterized_type(self, adapter):
-        sql = "`price` DECIMAL(10, 2)"
-        result = adapter.parse_column_definitions(sql)
-        assert result == [{"column_name": "price", "data_type": "DECIMAL(10, 2)"}]
-
-    def test_timestamp_precision(self, adapter):
-        sql = "`ts` TIMESTAMP(3)"
-        result = adapter.parse_column_definitions(sql)
-        assert result == [{"column_name": "ts", "data_type": "TIMESTAMP(3)"}]
-
-    def test_skips_watermark(self, adapter):
-        sql = "`ts` TIMESTAMP(3),\nWATERMARK FOR ts AS ts - INTERVAL '5' SECOND"
-        result = adapter.parse_column_definitions(sql)
-        assert result == [{"column_name": "ts", "data_type": "TIMESTAMP(3)"}]
-
-    def test_skips_primary_key(self, adapter):
-        sql = "`id` BIGINT,\nPRIMARY KEY(`id`) NOT ENFORCED"
-        result = adapter.parse_column_definitions(sql)
-        assert result == [{"column_name": "id", "data_type": "BIGINT"}]
-
-    def test_full_source_for_drift(self, adapter):
-        """Parse the full SOURCE_FOR_DRIFT fixture used in functional tests."""
-        sql = (
-            "`order_id` BIGINT,\n"
-            "`price` DECIMAL(10, 2),\n"
-            "`order_time` TIMESTAMP(3),\n"
-            "WATERMARK FOR order_time AS order_time - INTERVAL '5' SECOND,\n"
-            "PRIMARY KEY(`order_id`) NOT ENFORCED"
-        )
-        result = adapter.parse_column_definitions(sql)
-        assert result == [
-            {"column_name": "order_id", "data_type": "BIGINT"},
-            {"column_name": "price", "data_type": "DECIMAL(10, 2)"},
-            {"column_name": "order_time", "data_type": "TIMESTAMP(3)"},
-        ]
-
-    def test_single_column_no_comma(self, adapter):
-        sql = "`id` BIGINT"
-        result = adapter.parse_column_definitions(sql)
-        assert result == [{"column_name": "id", "data_type": "BIGINT"}]
-
-    def test_normalizes_types(self, adapter):
-        sql = "`price` decimal(10,2)"
-        result = adapter.parse_column_definitions(sql)
-        assert result == [{"column_name": "price", "data_type": "DECIMAL(10, 2)"}]
-
-    def test_array_type(self, adapter):
-        sql = "`tags` ARRAY<STRING>"
-        result = adapter.parse_column_definitions(sql)
-        assert result == [{"column_name": "tags", "data_type": "ARRAY<STRING>"}]
-
-    def test_map_type(self, adapter):
-        sql = "`data` MAP<STRING, INT>, `id` BIGINT"
-        result = adapter.parse_column_definitions(sql)
-        assert result == [
-            {"column_name": "data", "data_type": "MAP<STRING, INT>"},
-            {"column_name": "id", "data_type": "BIGINT"},
-        ]
-
-    def test_row_type(self, adapter):
-        sql = "`customer` ROW<name STRING, age INT>, `id` BIGINT"
-        result = adapter.parse_column_definitions(sql)
-        assert result == [
-            {"column_name": "customer", "data_type": "ROW<NAME STRING, AGE INT>"},
-            {"column_name": "id", "data_type": "BIGINT"},
-        ]
-
-    def test_multiword_type(self, adapter):
-        sql = "`ts` TIMESTAMP(3) WITH LOCAL TIME ZONE"
-        result = adapter.parse_column_definitions(sql)
-        assert result == [{"column_name": "ts", "data_type": "TIMESTAMP(3) WITH LOCAL TIME ZONE"}]
-
-    def test_nested_collection_type(self, adapter):
-        sql = "`matrix` ARRAY<ARRAY<INT>>, `id` BIGINT"
-        result = adapter.parse_column_definitions(sql)
-        assert result == [
-            {"column_name": "matrix", "data_type": "ARRAY<ARRAY<INT>>"},
-            {"column_name": "id", "data_type": "BIGINT"},
-        ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_schema_drift.py
+++ b/tests/unit/test_schema_drift.py
@@ -1,0 +1,266 @@
+"""Unit tests for schema drift detection logic in ConfluentAdapter."""
+
+import agate
+import pytest
+from dbt_common.exceptions import CompilationError
+
+from dbt.adapters.confluent.impl import ConfluentAdapter
+
+# ---------------------------------------------------------------------------
+# _normalize_type
+# ---------------------------------------------------------------------------
+
+class TestNormalizeType:
+    def test_simple_type(self):
+        assert ConfluentAdapter._normalize_type("bigint") == "BIGINT"
+
+    def test_parameterized_type(self):
+        assert ConfluentAdapter._normalize_type("DECIMAL(10, 2)") == "DECIMAL(10, 2)"
+
+    def test_no_space_after_comma(self):
+        assert ConfluentAdapter._normalize_type("DECIMAL(10,2)") == "DECIMAL(10, 2)"
+
+    def test_extra_spaces(self):
+        assert ConfluentAdapter._normalize_type("  decimal( 10 , 2 )  ") == "DECIMAL(10, 2)"
+
+    def test_timestamp_precision(self):
+        assert ConfluentAdapter._normalize_type("timestamp(3)") == "TIMESTAMP(3)"
+
+    def test_collapses_internal_whitespace(self):
+        assert ConfluentAdapter._normalize_type("DOUBLE   PRECISION") == "DOUBLE"
+
+    def test_array_angle_brackets(self):
+        assert ConfluentAdapter._normalize_type("ARRAY< INT >") == "ARRAY<INT>"
+
+    def test_map_angle_brackets(self):
+        assert ConfluentAdapter._normalize_type("map< string,int >") == "MAP<STRING, INT>"
+
+    def test_row_angle_brackets(self):
+        assert ConfluentAdapter._normalize_type("ROW< name STRING, age INT >") == "ROW<NAME STRING, AGE INT>"
+
+    def test_alias_string(self):
+        assert ConfluentAdapter._normalize_type("STRING") == "VARCHAR(2147483647)"
+
+    def test_alias_bytes(self):
+        assert ConfluentAdapter._normalize_type("BYTES") == "VARBINARY(2147483647)"
+
+    def test_alias_integer(self):
+        assert ConfluentAdapter._normalize_type("INTEGER") == "INT"
+
+    def test_alias_double_precision(self):
+        assert ConfluentAdapter._normalize_type("DOUBLE PRECISION") == "DOUBLE"
+
+    def test_alias_not_applied_to_parameterized(self):
+        """STRING alias should only match the bare keyword, not VARCHAR(n)."""
+        assert ConfluentAdapter._normalize_type("VARCHAR(100)") == "VARCHAR(100)"
+
+
+# ---------------------------------------------------------------------------
+# parse_column_definitions
+# ---------------------------------------------------------------------------
+
+class TestParseColumnDefinitions:
+    """Test the SQL column definition parser."""
+
+    @pytest.fixture
+    def adapter(self):
+        """Minimal adapter instance — only need the method, not a real connection."""
+        return ConfluentAdapter.__new__(ConfluentAdapter)
+
+    def test_basic_columns(self, adapter):
+        sql = "`id` BIGINT,\n`value` STRING"
+        result = adapter.parse_column_definitions(sql)
+        assert result == [
+            {"column_name": "id", "data_type": "BIGINT"},
+            {"column_name": "value", "data_type": "VARCHAR(2147483647)"},
+        ]
+
+    def test_parameterized_type(self, adapter):
+        sql = "`price` DECIMAL(10, 2)"
+        result = adapter.parse_column_definitions(sql)
+        assert result == [{"column_name": "price", "data_type": "DECIMAL(10, 2)"}]
+
+    def test_timestamp_precision(self, adapter):
+        sql = "`ts` TIMESTAMP(3)"
+        result = adapter.parse_column_definitions(sql)
+        assert result == [{"column_name": "ts", "data_type": "TIMESTAMP(3)"}]
+
+    def test_skips_watermark(self, adapter):
+        sql = "`ts` TIMESTAMP(3),\nWATERMARK FOR ts AS ts - INTERVAL '5' SECOND"
+        result = adapter.parse_column_definitions(sql)
+        assert result == [{"column_name": "ts", "data_type": "TIMESTAMP(3)"}]
+
+    def test_skips_primary_key(self, adapter):
+        sql = "`id` BIGINT,\nPRIMARY KEY(`id`) NOT ENFORCED"
+        result = adapter.parse_column_definitions(sql)
+        assert result == [{"column_name": "id", "data_type": "BIGINT"}]
+
+    def test_full_source_for_drift(self, adapter):
+        """Parse the full SOURCE_FOR_DRIFT fixture used in functional tests."""
+        sql = (
+            "`order_id` BIGINT,\n"
+            "`price` DECIMAL(10, 2),\n"
+            "`order_time` TIMESTAMP(3),\n"
+            "WATERMARK FOR order_time AS order_time - INTERVAL '5' SECOND,\n"
+            "PRIMARY KEY(`order_id`) NOT ENFORCED"
+        )
+        result = adapter.parse_column_definitions(sql)
+        assert result == [
+            {"column_name": "order_id", "data_type": "BIGINT"},
+            {"column_name": "price", "data_type": "DECIMAL(10, 2)"},
+            {"column_name": "order_time", "data_type": "TIMESTAMP(3)"},
+        ]
+
+    def test_single_column_no_comma(self, adapter):
+        sql = "`id` BIGINT"
+        result = adapter.parse_column_definitions(sql)
+        assert result == [{"column_name": "id", "data_type": "BIGINT"}]
+
+    def test_normalizes_types(self, adapter):
+        sql = "`price` decimal(10,2)"
+        result = adapter.parse_column_definitions(sql)
+        assert result == [{"column_name": "price", "data_type": "DECIMAL(10, 2)"}]
+
+    def test_array_type(self, adapter):
+        sql = "`tags` ARRAY<STRING>"
+        result = adapter.parse_column_definitions(sql)
+        assert result == [{"column_name": "tags", "data_type": "ARRAY<STRING>"}]
+
+    def test_map_type(self, adapter):
+        sql = "`data` MAP<STRING, INT>, `id` BIGINT"
+        result = adapter.parse_column_definitions(sql)
+        assert result == [
+            {"column_name": "data", "data_type": "MAP<STRING, INT>"},
+            {"column_name": "id", "data_type": "BIGINT"},
+        ]
+
+    def test_row_type(self, adapter):
+        sql = "`customer` ROW<name STRING, age INT>, `id` BIGINT"
+        result = adapter.parse_column_definitions(sql)
+        assert result == [
+            {"column_name": "customer", "data_type": "ROW<NAME STRING, AGE INT>"},
+            {"column_name": "id", "data_type": "BIGINT"},
+        ]
+
+    def test_multiword_type(self, adapter):
+        sql = "`ts` TIMESTAMP(3) WITH LOCAL TIME ZONE"
+        result = adapter.parse_column_definitions(sql)
+        assert result == [{"column_name": "ts", "data_type": "TIMESTAMP(3) WITH LOCAL TIME ZONE"}]
+
+    def test_nested_collection_type(self, adapter):
+        sql = "`matrix` ARRAY<ARRAY<INT>>, `id` BIGINT"
+        result = adapter.parse_column_definitions(sql)
+        assert result == [
+            {"column_name": "matrix", "data_type": "ARRAY<ARRAY<INT>>"},
+            {"column_name": "id", "data_type": "BIGINT"},
+        ]
+
+
+# ---------------------------------------------------------------------------
+# check_schema_drift
+# ---------------------------------------------------------------------------
+
+def _make_agate_table(rows):
+    """Create an agate.Table with column_name and data_type columns."""
+    return agate.Table(rows, column_names=["column_name", "data_type"])
+
+
+class TestCheckSchemaDrift:
+    """Test the drift comparison logic."""
+
+    @pytest.fixture
+    def adapter(self):
+        return ConfluentAdapter.__new__(ConfluentAdapter)
+
+    def test_no_drift(self, adapter):
+        existing = _make_agate_table([("id", "BIGINT"), ("value", "STRING")])
+        expected = _make_agate_table([("id", "BIGINT"), ("value", "STRING")])
+        # Should not raise
+        adapter.check_schema_drift("my_table", existing, expected, {}, {})
+
+    def test_no_drift_with_list_expected(self, adapter):
+        existing = _make_agate_table([("id", "BIGINT"), ("value", "STRING")])
+        expected = [
+            {"column_name": "id", "data_type": "BIGINT"},
+            {"column_name": "value", "data_type": "STRING"},
+        ]
+        adapter.check_schema_drift("my_table", existing, expected, {}, {})
+
+    def test_extra_column_detected(self, adapter):
+        existing = _make_agate_table([("id", "BIGINT")])
+        expected = _make_agate_table([("id", "BIGINT"), ("extra", "STRING")])
+        with pytest.raises(CompilationError, match="drift detected"):
+            adapter.check_schema_drift("t", existing, expected, {}, {})
+
+    def test_removed_column_detected(self, adapter):
+        existing = _make_agate_table([("id", "BIGINT"), ("value", "STRING")])
+        expected = _make_agate_table([("id", "BIGINT")])
+        with pytest.raises(CompilationError, match="drift detected"):
+            adapter.check_schema_drift("t", existing, expected, {}, {})
+
+    def test_renamed_column_detected(self, adapter):
+        existing = _make_agate_table([("id", "BIGINT"), ("value", "STRING")])
+        expected = _make_agate_table([("id", "BIGINT"), ("name", "STRING")])
+        with pytest.raises(CompilationError, match="drift detected"):
+            adapter.check_schema_drift("t", existing, expected, {}, {})
+
+    def test_type_change_detected(self, adapter):
+        existing = _make_agate_table([("id", "BIGINT")])
+        expected = _make_agate_table([("id", "INT")])
+        with pytest.raises(CompilationError, match="type mismatch"):
+            adapter.check_schema_drift("t", existing, expected, {}, {})
+
+    def test_column_order_ignored(self, adapter):
+        existing = _make_agate_table([("a", "BIGINT"), ("b", "STRING")])
+        expected = _make_agate_table([("b", "STRING"), ("a", "BIGINT")])
+        adapter.check_schema_drift("t", existing, expected, {}, {})
+
+    def test_case_insensitive_names(self, adapter):
+        existing = _make_agate_table([("ID", "BIGINT")])
+        expected = _make_agate_table([("id", "BIGINT")])
+        adapter.check_schema_drift("t", existing, expected, {}, {})
+
+    def test_type_normalization(self, adapter):
+        existing = _make_agate_table([("price", "DECIMAL(10, 2)")])
+        expected = [{"column_name": "price", "data_type": "decimal(10,2)"}]
+        adapter.check_schema_drift("t", existing, expected, {}, {})
+
+    def test_options_drift_detected(self, adapter):
+        existing = _make_agate_table([("id", "BIGINT")])
+        expected = _make_agate_table([("id", "BIGINT")])
+        with pytest.raises(CompilationError, match="drift detected"):
+            adapter.check_schema_drift(
+                "t", existing, expected,
+                expected_with={"changelog.mode": "append"},
+                existing_options={"changelog.mode": "upsert"},
+            )
+
+    def test_options_missing_detected(self, adapter):
+        existing = _make_agate_table([("id", "BIGINT")])
+        expected = _make_agate_table([("id", "BIGINT")])
+        with pytest.raises(CompilationError, match="drift detected"):
+            adapter.check_schema_drift(
+                "t", existing, expected,
+                expected_with={"changelog.mode": "append"},
+                existing_options={},
+            )
+
+    def test_extra_existing_options_allowed(self, adapter):
+        """Extra options in the existing table (e.g. connector defaults) are fine."""
+        existing = _make_agate_table([("id", "BIGINT")])
+        expected = _make_agate_table([("id", "BIGINT")])
+        adapter.check_schema_drift(
+            "t", existing, expected,
+            expected_with={"changelog.mode": "upsert"},
+            existing_options={"changelog.mode": "upsert", "connector": "faker"},
+        )
+
+    def test_no_options_check_when_empty(self, adapter):
+        """When expected_with is empty, no options comparison happens."""
+        existing = _make_agate_table([("id", "BIGINT")])
+        expected = _make_agate_table([("id", "BIGINT")])
+        adapter.check_schema_drift(
+            "t", existing, expected,
+            expected_with={},
+            existing_options={"anything": "here"},
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -222,9 +222,13 @@ wheels = [
 [[package]]
 name = "confluent-sql"
 version = "0.1.0"
-source = { git = "https://github.com/confluentinc/confluent-sql#973a0a819fa861e671fa1659100e998a41416f6b" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/1b/5208625e5890511157861d71aa2d25b077586581d7a2cb557d9895183efd/confluent_sql-0.1.0.tar.gz", hash = "sha256:e7a0c0dffc592ba9b52396f0bcaa601e7147e2bdd1d92da32261bc76f189fb91", size = 173531, upload-time = "2026-03-19T17:24:29.227Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/df/019f18513db634b37eb69f08e48140317a1f4c57d4dc3e2083c026ec1401/confluent_sql-0.1.0-py3-none-any.whl", hash = "sha256:32319ba543e8d0bbe031c9154e554227e88fbbf59dd8a6cedfaf12897fe7f7aa", size = 66432, upload-time = "2026-03-19T17:24:30.389Z" },
 ]
 
 [[package]]
@@ -306,7 +310,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "agate", specifier = "~=1.0" },
-    { name = "confluent-sql", git = "https://github.com/confluentinc/confluent-sql" },
+    { name = "confluent-sql", specifier = "~=0.1" },
     { name = "dbt-adapters", specifier = "~=1.16" },
     { name = "dbt-common", specifier = "~=1.12" },
     { name = "dbt-core", specifier = "~=1.11" },


### PR DESCRIPTION
# Schema Drift Detection

Adds schema drift detection for `table`, `streaming_table`, and `streaming_source` materializations. When a table already exists and `--full-refresh` is not set, the adapter validates columns (names, types) and WITH options against the existing table. If drift is detected, it raises an error (configurable via `on_schema_drift: 'fail' | 'ignore'`). If no drift, it skips creation idempotently.

This also means repeated `dbt run` without `--full-refresh` is now idempotent — previously it would error on existing tables, forcing users to always pass `--full-refresh` or manage tables manually.

Schema is inferred by creating a temporary table from the model's SQL/column definitions and comparing against INFORMATION_SCHEMA, rather than parsing SQL ourselves.

## Other changes

- **Removed `materialized_view` materialization** — replaced with error directing users to `table`. In Confluent Flink, CTAS tables are continuously updated by Flink, making them functionally equivalent. The `materialized_view` name was misleading since dbt's semantics for it don't match Flink's continuous processing model.
- **Added `validate_column_data_types()`** catches constraint keywords (NOT NULL, VIRTUAL, METADATA) misplaced in data_type fields. Without this, users get cryptic SQL parse errors; this gives a clear message instead.
- **Pinned `confluent-sql` to PyPI 0.1** (was git source)
- **Version bump to 0.2.0** (breaking: materialized_view removal)

## Known limitations

- Cannot detect removed WITH options. Connectors add default options automatically (e.g., faker adds `fields.*.expression`), so we can't distinguish user-specified from auto-generated. Users must use `--full-refresh` to remove options.
- Column reordering is intentionally allowed (order doesn't matter for Kafka-backed tables)
