### PR TITLE
[APPSEC-6902] Add --frozen flag to uv sync in Semaphore CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -22,7 +22,7 @@ global_job_config:
       - . vault-setup
       - git submodule update --init
       - curl -LsSf https://astral.sh/uv/install.sh | sh
-      - uv sync --extra dev --extra test
+      - uv sync --locked --extra dev --extra test
 
 blocks:
   - name: "Lint"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -22,7 +22,7 @@ global_job_config:
       - . vault-setup
       - git submodule update --init
       - curl -LsSf https://astral.sh/uv/install.sh | sh
-      - uv sync --locked --extra dev --extra test
+      - uv sync --frozen --extra dev --extra test
 
 blocks:
   - name: "Lint"


### PR DESCRIPTION
## Summary
- Adds `--frozen` flag to `uv sync` in `.semaphore/semaphore.yml`
- Ensures CI dependency resolution uses the lockfile without attempting to update it
- This change will prevent compromised malicious PyPI packages from immediately affecting CI jobs

## Test plan
- [ ] Verify Semaphore CI pipeline passes with `--frozen` flag
- [ ] Confirm `uv.lock` is up-to-date in the repo (if not, run `uv lock` first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)