### PR TITLE
Update confluent sql

### DIFF
--- a/changes/39.feature.md
+++ b/changes/39.feature.md
@@ -1,0 +1,1 @@
+Mark internal/metadata queries with the hidden label so they are filtered by default in the Confluent UI

--- a/changes/40.misc.md
+++ b/changes/40.misc.md
@@ -1,0 +1,1 @@
+Update to confluent-sql 0.3

--- a/changes/44.feature.md
+++ b/changes/44.feature.md
@@ -1,0 +1,1 @@
+Add custom endpoint configuration for private and other non-standard cluster urls

--- a/dbt/adapters/confluent/connections.py
+++ b/dbt/adapters/confluent/connections.py
@@ -7,8 +7,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import confluent_sql
-from confluent_sql import Cursor
-from confluent_sql.exceptions import ComputePoolExhaustedError
+from confluent_sql import HIDDEN_LABEL, Cursor
+from confluent_sql.exceptions import ComputePoolExhaustedError, StatementNotFoundError
 from confluent_sql.execution_mode import ExecutionMode
 from dbt_common.events.contextvars import get_node_info
 from dbt_common.events.functions import fire_event
@@ -51,12 +51,13 @@ class ConfluentCredentials(Credentials):
     """
 
     # Add credentials members here, like:
-    cloud_provider: str
-    cloud_region: str
     compute_pool_id: str
     organization_id: str
     flink_api_key: str
     flink_api_secret: str
+    cloud_provider: str | None = None
+    cloud_region: str | None = None
+    endpoint: str | None = None
     execution_mode: ExecutionMode = ExecutionMode.STREAMING_QUERY
     statement_name_prefix: str = "dbt-confluent-"
     statement_label: str = "dbt-confluent"
@@ -80,7 +81,11 @@ class ConfluentCredentials(Credentials):
         """
         List of keys to display in the `dbt debug` output.
         """
-        return ("organization_id", "database", "schema")
+        keys = ("organization_id", "database", "schema")
+        if self.endpoint:
+            return (*keys, "endpoint")
+        else:
+            return (*keys, "cloud_provider", "cloud_region")
 
 
 class ConfluentConnectionManager(SQLConnectionManager):
@@ -107,12 +112,13 @@ class ConfluentConnectionManager(SQLConnectionManager):
         fetch: bool = False,
         limit: int | None = None,
         execution_mode: str | None = None,
+        hidden: bool = False,
     ) -> tuple[AdapterResponse, "agate.Table"]:
-        """This is customized so we can pass execution_mode down the chain."""
+        """This is customized so we can pass execution_mode and hidden down the chain."""
         from dbt_common.clients.agate_helper import empty_table
 
         sql = self._add_query_comment(sql)
-        _, cursor = self.add_query(sql, auto_begin, execution_mode=execution_mode)
+        _, cursor = self.add_query(sql, auto_begin, execution_mode=execution_mode, hidden=hidden)
         response = self.get_response(cursor)
         if fetch:
             table = self.get_result_from_cursor(cursor, limit)
@@ -130,6 +136,7 @@ class ConfluentConnectionManager(SQLConnectionManager):
         retryable_exceptions: tuple[type[Exception], ...] = (ComputePoolExhaustedError,),
         retry_limit: int = 5,
         execution_mode: str | None = None,
+        hidden: bool = False,
     ) -> tuple[Connection, Any]:
         """
         Copied from upstream (in SqlConnectionManager) with handling of cursor's
@@ -145,7 +152,7 @@ class ConfluentConnectionManager(SQLConnectionManager):
             retry_limit: int,
             attempt: int,
             statement_name: str | None = None,
-            statement_label: str | None = None,
+            statement_labels: list[str] | None = None,
         ):
             """
             A success sees the try exit cleanly and avoid any recursive
@@ -153,7 +160,7 @@ class ConfluentConnectionManager(SQLConnectionManager):
             """
             try:
                 cursor.execute(
-                    sql, bindings, statement_name=statement_name, statement_label=statement_label
+                    sql, bindings, statement_name=statement_name, statement_labels=statement_labels
                 )
             except retryable_exceptions as e:
                 # Cease retries and fail when limit is hit.
@@ -191,7 +198,7 @@ class ConfluentConnectionManager(SQLConnectionManager):
                     retry_limit=retry_limit,
                     attempt=attempt + 1,
                     statement_name=retry_statement_name,
-                    statement_label=statement_label,
+                    statement_labels=statement_labels,
                 )
 
         connection = self.get_thread_connection()
@@ -228,7 +235,9 @@ class ConfluentConnectionManager(SQLConnectionManager):
 
             prefix = connection.credentials.statement_name_prefix
             statement_name = f"{prefix}{uuid.uuid4()}"
-            label = connection.credentials.statement_label
+            labels = [connection.credentials.statement_label]
+            if hidden:
+                labels.append(HIDDEN_LABEL)
             cursor = connection.handle.cursor(mode=resolved_mode)
             _execute_query_with_retry(
                 cursor=cursor,
@@ -238,7 +247,7 @@ class ConfluentConnectionManager(SQLConnectionManager):
                 retry_limit=retry_limit,
                 attempt=1,
                 statement_name=statement_name,
-                statement_label=label,
+                statement_labels=labels,
             )
 
             result = self.get_response(cursor)
@@ -262,6 +271,10 @@ class ConfluentConnectionManager(SQLConnectionManager):
         """
         try:
             yield
+        except StatementNotFoundError as e:
+            msg = f"Statement '{e.statement_name}' not found for '{sql}': {e}"
+            logger.debug(msg)
+            raise DbtDatabaseError(msg) from e
         except confluent_sql.Error as e:
             # TODO: Use logger, or fire a dbt event? Or both?
             msg = f"confluent_sql error for '{sql}': {e}"
@@ -292,12 +305,13 @@ class ConfluentConnectionManager(SQLConnectionManager):
             handle = confluent_sql.connect(
                 flink_api_key=credentials.flink_api_key,
                 flink_api_secret=credentials.flink_api_secret,
-                environment=credentials.database,
+                environment_id=credentials.database,
                 compute_pool_id=credentials.compute_pool_id,
                 organization_id=credentials.organization_id,
                 cloud_provider=credentials.cloud_provider,
                 cloud_region=credentials.cloud_region,
-                dbname=credentials.schema,
+                endpoint=credentials.endpoint,
+                database=credentials.schema,
                 http_user_agent=user_agent,
             )
             connection.state = "open"

--- a/dbt/adapters/confluent/connections.py
+++ b/dbt/adapters/confluent/connections.py
@@ -75,7 +75,10 @@ class ConfluentCredentials(Credentials):
         Hashed and included in anonymous telemetry to track adapter adoption.
         Pick a field that can uniquely identify one team/organization building with this adapter
         """
-        return f"{self.cloud_provider}-{self.cloud_region}-{self.organization_id}"
+        if self.endpoint:
+            return self.endpoint
+        else:
+            return f"{self.cloud_provider}-{self.cloud_region}-{self.organization_id}"
 
     def _connection_keys(self):
         """

--- a/dbt/adapters/confluent/impl.py
+++ b/dbt/adapters/confluent/impl.py
@@ -106,6 +106,7 @@ class ConfluentAdapter(SQLAdapter):
         fetch: bool = False,
         limit: int | None = None,
         execution_mode: str | None = None,
+        hidden: bool = False,
     ) -> tuple[AdapterResponse, "agate.Table"]:
         return self.connections.execute(
             sql=sql,
@@ -113,6 +114,7 @@ class ConfluentAdapter(SQLAdapter):
             fetch=fetch,
             limit=limit,
             execution_mode=execution_mode,
+            hidden=hidden,
         )
 
     @classmethod

--- a/dbt/include/confluent/macros/adapters/columns.sql
+++ b/dbt/include/confluent/macros/adapters/columns.sql
@@ -1,5 +1,5 @@
 {% macro confluent__get_columns_in_relation(relation) -%}
-  {% call statement('get_columns_in_relation', fetch_result=True) %}
+  {% call statement('get_columns_in_relation', fetch_result=True, hidden=True) %}
     SELECT
       COLUMN_NAME as column_name,
       FULL_DATA_TYPE as data_type,

--- a/dbt/include/confluent/macros/adapters/metadata.sql
+++ b/dbt/include/confluent/macros/adapters/metadata.sql
@@ -1,5 +1,5 @@
 {% macro confluent__get_catalog(information_schema, schemas) -%}
-    {% call statement('get_catalog', fetch_result=True) %}
+    {% call statement('get_catalog', fetch_result=True, hidden=True) %}
     select
         TABLE_CATALOG_ID as table_database,
         TABLE_SCHEMA as table_schema,
@@ -53,7 +53,7 @@
 {% endmacro %}
 
 {% macro confluent__list_relations_without_caching(schema_relation) -%}
-  {% call statement('list_relations_without_caching', fetch_result=True) -%}
+  {% call statement('list_relations_without_caching', fetch_result=True, hidden=True) -%}
     SELECT
       TABLE_CATALOG_ID as database,
       TABLE_NAME as name,
@@ -83,7 +83,7 @@
 {% endmacro %}
 
 {% macro confluent__list_schemas(database) -%}
-  {% call statement('list_schemas', fetch_result=True) -%}
+  {% call statement('list_schemas', fetch_result=True, hidden=True) -%}
     SELECT
       SCHEMA_NAME as schema
     FROM

--- a/dbt/include/confluent/macros/etc/statement.sql
+++ b/dbt/include/confluent/macros/etc/statement.sql
@@ -7,7 +7,8 @@
   auto_begin=True,
   language='sql',
   limit=None,
-  execution_mode=None
+  execution_mode=None,
+  hidden=False
 ) -%}
   {%- if execute: -%}
     {%- set compiled_code = caller() -%}
@@ -20,7 +21,7 @@
       {% if not execution_mode %}
         {% set execution_mode = config.get("execution_mode", None) %}
       {% endif %}
-      {%- set res, table = adapter.execute(compiled_code, auto_begin=auto_begin, fetch=fetch_result, execution_mode=execution_mode, limit=limit) -%}
+      {%- set res, table = adapter.execute(compiled_code, auto_begin=auto_begin, fetch=fetch_result, execution_mode=execution_mode, limit=limit, hidden=hidden) -%}
     {%- elif language == 'python' -%}
       {%- set res = submit_python_job(model, compiled_code) -%}
       {#-- TODO: What should table be for python models? --#}

--- a/dbt/include/confluent/macros/materializations/models/helpers.sql
+++ b/dbt/include/confluent/macros/materializations/models/helpers.sql
@@ -58,7 +58,7 @@
 
 {% macro get_existing_columns(relation) %}
   {# Fetch column name and type from INFORMATION_SCHEMA.COLUMNS for the given relation. #}
-  {% call statement('get_existing_columns', fetch_result=True) %}
+  {% call statement('get_existing_columns', fetch_result=True, hidden=True) %}
     SELECT
       COLUMN_NAME as column_name,
       FULL_DATA_TYPE as data_type
@@ -89,7 +89,7 @@
   ) %}
 
   {# Create temp table from the query #}
-  {% call statement('create_temp_table') %}
+  {% call statement('create_temp_table', hidden=True) %}
     CREATE TABLE {{ temp_relation }} AS
     SELECT * FROM (
       {{ model_sql }}
@@ -100,7 +100,7 @@
   {% set expected_columns = get_existing_columns(temp_relation) %}
 
   {# Drop the temp table #}
-  {% call statement('drop_temp_table') %}
+  {% call statement('drop_temp_table', hidden=True) %}
     DROP TABLE IF EXISTS {{ temp_relation }}
   {% endcall %}
 
@@ -123,7 +123,7 @@
   ) %}
 
   {# Create temp table from column definitions (without connector) #}
-  {% call statement('create_temp_table') %}
+  {% call statement('create_temp_table', hidden=True) %}
     CREATE TABLE {{ temp_relation }} ( {{ column_definitions }} )
   {% endcall %}
 
@@ -131,7 +131,7 @@
   {% set expected_columns = get_existing_columns(temp_relation) %}
 
   {# Drop the temp table #}
-  {% call statement('drop_temp_table') %}
+  {% call statement('drop_temp_table', hidden=True) %}
     DROP TABLE IF EXISTS {{ temp_relation }}
   {% endcall %}
 
@@ -142,7 +142,7 @@
 {% macro get_existing_table_options(relation) %}
   {# Fetch WITH options from INFORMATION_SCHEMA.TABLE_OPTIONS for the given relation.
      Returns a dict of {option_key: option_value}. #}
-  {% call statement('get_existing_table_options', fetch_result=True) %}
+  {% call statement('get_existing_table_options', fetch_result=True, hidden=True) %}
     SELECT
       OPTION_KEY,
       OPTION_VALUE

--- a/dbt/include/confluent/profile_template.yml
+++ b/dbt/include/confluent/profile_template.yml
@@ -1,12 +1,17 @@
 fixed:
   type: confluent
 prompts:
-  cloud_provider:
-    hint: "eg: 'aws'"
-    default: "aws"
-  cloud_region:
-    hint: "eg: us-west-1"
-    default: "us-west-1"
+  _choose_backend_url:
+    "Use cloud_provider and cloud_region":
+      cloud_provider:
+        hint: "eg: 'aws'"
+        default: "aws"
+      cloud_region:
+        hint: "eg: us-west-1"
+        default: "us-west-1"
+    "Use a custom endpoint":
+      endpoint:
+        hint: "eg: https://flink.us-east-2.aws.private.confluent.cloud"
   organization_id:
     hint: "eg: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   compute_pool_id:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "dbt-adapters~=1.16",
   "agate~=1.0",
   "httpx>=0.23.0,<0.29.0",
-  "confluent-sql~=0.1",
+  "confluent-sql~=0.3",
 ]
 
 [dependency-groups]

--- a/tests/unit/test_profile_template.py
+++ b/tests/unit/test_profile_template.py
@@ -1,0 +1,108 @@
+from pathlib import Path
+from unittest import mock
+
+import click
+import yaml
+from dbt.task.init import InitTask
+
+PROFILE_TEMPLATE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "dbt"
+    / "include"
+    / "confluent"
+    / "profile_template.yml"
+)
+
+
+def load_profile_template():
+    with open(PROFILE_TEMPLATE_PATH) as f:
+        return yaml.safe_load(f)
+
+
+def _run_generate_target(prompts_section, prompt_responses):
+    """Helper to run generate_target_from_input with mocked click.prompt."""
+    task = InitTask.__new__(InitTask)
+    with mock.patch("click.prompt", side_effect=prompt_responses):
+        # Pass a fresh dict to avoid dbt-core's mutable default argument bug
+        return task.generate_target_from_input(prompts_section, target={})
+
+
+class TestProfileTemplate:
+    def test_template_is_valid_yaml(self):
+        template = load_profile_template()
+        assert "fixed" in template
+        assert template["fixed"]["type"] == "confluent"
+        assert "prompts" in template
+
+    def test_choose_cloud_provider_region(self):
+        """Choosing 'Use cloud_provider and cloud_region' prompts for provider and region."""
+        template = load_profile_template()
+        prompt_responses = [
+            1,                  # _choose_backend_url: "Use cloud_provider and cloud_region"
+            "aws",              # cloud_provider
+            "us-west-1",        # cloud_region
+            "org-123",          # organization_id
+            "lfcp-abc",         # compute_pool_id
+            "env-xyz",          # environment_id
+            "my_db",            # dbname
+            "my-key",           # flink_api_key
+            "my-secret",        # flink_api_secret
+            "streaming_query",  # execution_mode
+            "dbt-confluent-",   # statement_name_prefix
+            "dbt-confluent",    # statement_label
+            1,                  # threads
+        ]
+
+        target = _run_generate_target(template["prompts"], prompt_responses)
+
+        assert target["cloud_provider"] == "aws"
+        assert target["cloud_region"] == "us-west-1"
+        assert "endpoint" not in target
+
+    def test_choose_custom_endpoint(self):
+        """Choosing 'Use a custom endpoint' prompts for endpoint only."""
+        template = load_profile_template()
+        endpoint_url = "https://flink.us-east-2.aws.private.confluent.cloud"
+        prompt_responses = [
+            2,                  # _choose_backend_url: "Use a custom endpoint"
+            endpoint_url,       # endpoint
+            "org-123",          # organization_id
+            "lfcp-abc",         # compute_pool_id
+            "env-xyz",          # environment_id
+            "my_db",            # dbname
+            "my-key",           # flink_api_key
+            "my-secret",        # flink_api_secret
+            "streaming_query",  # execution_mode
+            "dbt-confluent-",   # statement_name_prefix
+            "dbt-confluent",    # statement_label
+            1,                  # threads
+        ]
+
+        target = _run_generate_target(template["prompts"], prompt_responses)
+
+        assert target["endpoint"] == endpoint_url
+        assert "cloud_provider" not in target
+        assert "cloud_region" not in target
+
+    def test_choose_prompt_message_contains_option_labels(self):
+        """Verify the _choose_ prompt displays the human-readable option labels."""
+        template = load_profile_template()
+
+        with mock.patch("click.prompt") as mock_prompt:
+            # We only care about the first call (the _choose_ prompt),
+            # so raise StopIteration after it to abort early.
+            mock_prompt.side_effect = [1, StopIteration]
+            task = InitTask.__new__(InitTask)
+
+            # Just run the _choose_ part
+            choose_section = {"_choose_backend_url": template["prompts"]["_choose_backend_url"]}
+            try:
+                task.generate_target_from_input(choose_section)
+            except StopIteration:
+                pass
+
+            first_call_args = mock_prompt.call_args_list[0]
+            prompt_msg = first_call_args[0][0]
+            assert "Use cloud_provider and cloud_region" in prompt_msg
+            assert "Use a custom endpoint" in prompt_msg
+            assert first_call_args[1]["type"] is click.INT

--- a/tests/unit/test_profile_template.py
+++ b/tests/unit/test_profile_template.py
@@ -3,14 +3,11 @@ from unittest import mock
 
 import click
 import yaml
+
 from dbt.task.init import InitTask
 
 PROFILE_TEMPLATE_PATH = (
-    Path(__file__).resolve().parents[2]
-    / "dbt"
-    / "include"
-    / "confluent"
-    / "profile_template.yml"
+    Path(__file__).resolve().parents[2] / "dbt" / "include" / "confluent" / "profile_template.yml"
 )
 
 
@@ -38,19 +35,19 @@ class TestProfileTemplate:
         """Choosing 'Use cloud_provider and cloud_region' prompts for provider and region."""
         template = load_profile_template()
         prompt_responses = [
-            1,                  # _choose_backend_url: "Use cloud_provider and cloud_region"
-            "aws",              # cloud_provider
-            "us-west-1",        # cloud_region
-            "org-123",          # organization_id
-            "lfcp-abc",         # compute_pool_id
-            "env-xyz",          # environment_id
-            "my_db",            # dbname
-            "my-key",           # flink_api_key
-            "my-secret",        # flink_api_secret
+            1,  # _choose_backend_url: "Use cloud_provider and cloud_region"
+            "aws",  # cloud_provider
+            "us-west-1",  # cloud_region
+            "org-123",  # organization_id
+            "lfcp-abc",  # compute_pool_id
+            "env-xyz",  # environment_id
+            "my_db",  # dbname
+            "my-key",  # flink_api_key
+            "my-secret",  # flink_api_secret
             "streaming_query",  # execution_mode
-            "dbt-confluent-",   # statement_name_prefix
-            "dbt-confluent",    # statement_label
-            1,                  # threads
+            "dbt-confluent-",  # statement_name_prefix
+            "dbt-confluent",  # statement_label
+            1,  # threads
         ]
 
         target = _run_generate_target(template["prompts"], prompt_responses)
@@ -64,18 +61,18 @@ class TestProfileTemplate:
         template = load_profile_template()
         endpoint_url = "https://flink.us-east-2.aws.private.confluent.cloud"
         prompt_responses = [
-            2,                  # _choose_backend_url: "Use a custom endpoint"
-            endpoint_url,       # endpoint
-            "org-123",          # organization_id
-            "lfcp-abc",         # compute_pool_id
-            "env-xyz",          # environment_id
-            "my_db",            # dbname
-            "my-key",           # flink_api_key
-            "my-secret",        # flink_api_secret
+            2,  # _choose_backend_url: "Use a custom endpoint"
+            endpoint_url,  # endpoint
+            "org-123",  # organization_id
+            "lfcp-abc",  # compute_pool_id
+            "env-xyz",  # environment_id
+            "my_db",  # dbname
+            "my-key",  # flink_api_key
+            "my-secret",  # flink_api_secret
             "streaming_query",  # execution_mode
-            "dbt-confluent-",   # statement_name_prefix
-            "dbt-confluent",    # statement_label
-            1,                  # threads
+            "dbt-confluent-",  # statement_name_prefix
+            "dbt-confluent",  # statement_label
+            1,  # threads
         ]
 
         target = _run_generate_target(template["prompts"], prompt_responses)

--- a/uv.lock
+++ b/uv.lock
@@ -212,14 +212,14 @@ wheels = [
 
 [[package]]
 name = "confluent-sql"
-version = "0.1.0"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/1b/5208625e5890511157861d71aa2d25b077586581d7a2cb557d9895183efd/confluent_sql-0.1.0.tar.gz", hash = "sha256:e7a0c0dffc592ba9b52396f0bcaa601e7147e2bdd1d92da32261bc76f189fb91", size = 173531, upload-time = "2026-03-19T17:24:29.227Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/80/f2482406c87fb325546c38cabca9bc32ee26a03bc41b58b3ac8aa0cd6b73/confluent_sql-0.3.0.tar.gz", hash = "sha256:9791ad7b66d43b2d4cbb8a13d4d45c4cb44e645818d051aa7a8d493a216974f7", size = 188089, upload-time = "2026-04-09T14:33:59.469Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/df/019f18513db634b37eb69f08e48140317a1f4c57d4dc3e2083c026ec1401/confluent_sql-0.1.0-py3-none-any.whl", hash = "sha256:32319ba543e8d0bbe031c9154e554227e88fbbf59dd8a6cedfaf12897fe7f7aa", size = 66432, upload-time = "2026-03-19T17:24:30.389Z" },
+    { url = "https://files.pythonhosted.org/packages/66/92/df5f3daa8eb7ca73a2ceb70baccf90c97e3fd12e70aa24a6f7fc52ef42b3/confluent_sql-0.3.0-py3-none-any.whl", hash = "sha256:e591a6f1433d2ac6650dc4835b429cf4a69048a31fcde12be6fd00e724eb662c", size = 73519, upload-time = "2026-04-09T14:33:58.363Z" },
 ]
 
 [[package]]
@@ -309,7 +309,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "agate", specifier = "~=1.0" },
-    { name = "confluent-sql", specifier = "~=0.1" },
+    { name = "confluent-sql", specifier = "~=0.3" },
     { name = "dbt-adapters", specifier = "~=1.16" },
     { name = "dbt-common", specifier = "~=1.12" },
     { name = "dbt-core", specifier = "~=1.11" },


### PR DESCRIPTION
This PR upgrades `confluent-sql` from `~=0.1` to `~=0.3` and adopts its new APIs.
Fixes #39 
Fixes #40 
Fixes #44

  **Breaking changes:**
  - `cloud_provider` and `cloud_region` are now optional in the connection profile. A new `endpoint` field can be used instead to connect to a custom Flink endpoint (e.g. private networking).
  - `dbt init` now prompts users to choose between cloud_provider/cloud_region or a custom endpoint.

  **Internal changes (driven by confluent-sql 0.3):**
  - `statement_label` replaced with `statement_labels` (list) to support multiple labels per statement.
  - New `hidden` flag on internal/metadata queries (schema introspection, drift detection temp tables) so they can be filtered out in the Confluent Cloud UI.
  - `StatementNotFoundError` is now caught and surfaced as a `DbtDatabaseError`.
  - `confluent_sql.connect()` parameter renames: `environment` to `environment_id`, `dbname` to `database`.

  Includes unit tests for the updated profile template.
