### PR TITLE
Deterministic statements names

### DIFF
--- a/MATERIALIZATIONS.md
+++ b/MATERIALIZATIONS.md
@@ -83,6 +83,36 @@ This is an inherent limitation — `INFORMATION_SCHEMA` only stores schema metad
 ### When Drift is Detected
 If drift is detected, the run will fail with a compilation error. Use `--full-refresh` to drop and recreate the table with the new schema or options.
 
+## Deterministic Statement Names
+
+Each materialization creates Flink statements with deterministic names derived from the dbt project and model names:
+
+```
+{prefix}{project_name}-{model_name}
+```
+
+The default prefix is `dbt-`. For `streaming_table`, which creates two statements (a DDL and an INSERT), the DDL gets a `-ddl` suffix: `dbt-{project}-{model}-ddl`.
+
+### Flink Naming Constraints
+
+Flink statement names must contain only lowercase alphanumeric characters and hyphens, start with an alphanumeric character, and be at most 100 characters long. The adapter sanitizes names automatically:
+
+- Illegal characters (including underscores) are replaced with hyphens
+- A 6-char MD5 hash suffix is appended when characters are replaced, to avoid collisions (e.g. `my_model` and `my.model` produce different names)
+- Names exceeding 100 characters are truncated with a 6-char hash suffix
+
+### Custom Statement Names
+
+Override the generated name with the `statement_name` config:
+
+```sql
+{{ config(materialized='streaming_table', statement_name='my-custom-name') }}
+```
+
+### Statement Lifecycle
+
+On `--full-refresh`, the adapter deletes existing statements before dropping and recreating the table. When no relation exists, orphaned statements are also cleaned up. This enables idempotent re-runs and crash recovery.
+
 ## Not Supported
 
 | Materialization | Reason |

--- a/changes/29.bugfix.md
+++ b/changes/29.bugfix.md
@@ -1,0 +1,1 @@
+Delete existing statements before re-submitting with the same deterministic name on `--full-refresh`

--- a/changes/29.feature.md
+++ b/changes/29.feature.md
@@ -1,1 +1,1 @@
-Use deterministic names for Flink statements, laying the groundwork for future orphan cleanup, idempotent re-runs, and crash recovery
+Use deterministic names for Flink statements, laying the groundwork for future orphan cleanup, idempotent re-runs, and crash recovery. The default `statement_name_prefix` changed from `dbt-confluent-` to `dbt-`.

--- a/changes/29.feature.md
+++ b/changes/29.feature.md
@@ -1,0 +1,1 @@
+Use deterministic names for Flink statements, laying the groundwork for future orphan cleanup, idempotent re-runs, and crash recovery

--- a/dbt/adapters/confluent/connections.py
+++ b/dbt/adapters/confluent/connections.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import confluent_sql
+import httpx
 from confluent_sql import HIDDEN_LABEL, Cursor
 from confluent_sql.exceptions import ComputePoolExhaustedError, StatementNotFoundError
 from confluent_sql.execution_mode import ExecutionMode
@@ -143,7 +144,10 @@ class ConfluentConnectionManager(SQLConnectionManager):
         auto_begin: bool = True,
         bindings: Any | None = None,
         abridge_sql_log: bool = False,
-        retryable_exceptions: tuple[type[Exception], ...] = (ComputePoolExhaustedError,),
+        retryable_exceptions: tuple[type[Exception], ...] = (
+            ComputePoolExhaustedError,
+            httpx.TimeoutException,
+        ),
         retry_limit: int = 5,
         execution_mode: str | None = None,
         hidden: bool = False,

--- a/dbt/adapters/confluent/connections.py
+++ b/dbt/adapters/confluent/connections.py
@@ -59,7 +59,7 @@ class ConfluentCredentials(Credentials):
     cloud_region: str | None = None
     endpoint: str | None = None
     execution_mode: ExecutionMode = ExecutionMode.STREAMING_QUERY
-    statement_name_prefix: str = "dbt-confluent-"
+    statement_name_prefix: str = "dbt-"
     statement_label: str = "dbt-confluent"
 
     _ALIASES = {"environment_id": "database", "dbname": "schema"}
@@ -116,12 +116,15 @@ class ConfluentConnectionManager(SQLConnectionManager):
         limit: int | None = None,
         execution_mode: str | None = None,
         hidden: bool = False,
+        statement_name: str | None = None,
     ) -> tuple[AdapterResponse, "agate.Table"]:
-        """This is customized so we can pass execution_mode and hidden down the chain."""
+        """This is customized so we can pass execution_mode, hidden and statement_name down the chain."""
         from dbt_common.clients.agate_helper import empty_table
 
         sql = self._add_query_comment(sql)
-        _, cursor = self.add_query(sql, auto_begin, execution_mode=execution_mode, hidden=hidden)
+        _, cursor = self.add_query(
+            sql, auto_begin, execution_mode=execution_mode, statement_name=statement_name, hidden=hidden
+        )
         response = self.get_response(cursor)
         if fetch:
             table = self.get_result_from_cursor(cursor, limit)
@@ -140,11 +143,15 @@ class ConfluentConnectionManager(SQLConnectionManager):
         retry_limit: int = 5,
         execution_mode: str | None = None,
         hidden: bool = False,
+        statement_name: str | None = None,
     ) -> tuple[Connection, Any]:
         """
         Copied from upstream (in SqlConnectionManager) with handling of cursor's
-        execution_mode. ExecutionMode can be specified at the project level in credentials,
-        or as a node info in config blocks.
+        execution_mode, hidden label and statement_name. ExecutionMode can be specified at
+        the project level in credentials, or as a node info in config blocks.
+
+        statement_name: if provided, used as the Flink statement name (deterministic).
+        If None, a UUID-based name is generated (for metadata/schema queries).
         """
 
         def _execute_query_with_retry(
@@ -189,10 +196,8 @@ class ConfluentConnectionManager(SQLConnectionManager):
                     )
                 time.sleep(backoff)
 
-                # Generate a new statement name for the retry since the
-                # previous one may have been deleted by ComputePoolExhaustedError.
-                prefix = connection.credentials.statement_name_prefix
-                retry_statement_name = f"{prefix}{uuid.uuid4()}" if statement_name else None
+                # Reuse the same statement name on retry. ComputePoolExhaustedError
+                # cleans up the failed statement, so the name is available for reuse.
                 return _execute_query_with_retry(
                     cursor=cursor,
                     sql=sql,
@@ -200,8 +205,8 @@ class ConfluentConnectionManager(SQLConnectionManager):
                     retryable_exceptions=retryable_exceptions,
                     retry_limit=retry_limit,
                     attempt=attempt + 1,
-                    statement_name=retry_statement_name,
                     statement_labels=statement_labels,
+                    statement_name=statement_name,
                 )
 
         connection = self.get_thread_connection()
@@ -237,10 +242,15 @@ class ConfluentConnectionManager(SQLConnectionManager):
                 resolved_mode = ExecutionMode(connection.credentials.execution_mode)
 
             prefix = connection.credentials.statement_name_prefix
-            statement_name = f"{prefix}{uuid.uuid4()}"
             labels = [connection.credentials.statement_label]
             if hidden:
                 labels.append(HIDDEN_LABEL)
+
+            # Use deterministic name if provided, otherwise fall back to UUID
+            if statement_name is None:
+                prefix = connection.credentials.statement_name_prefix
+                statement_name = f"{prefix}{uuid.uuid4()}"
+
             cursor = connection.handle.cursor(mode=resolved_mode)
             _execute_query_with_retry(
                 cursor=cursor,

--- a/dbt/adapters/confluent/connections.py
+++ b/dbt/adapters/confluent/connections.py
@@ -123,7 +123,11 @@ class ConfluentConnectionManager(SQLConnectionManager):
 
         sql = self._add_query_comment(sql)
         _, cursor = self.add_query(
-            sql, auto_begin, execution_mode=execution_mode, statement_name=statement_name, hidden=hidden
+            sql,
+            auto_begin,
+            execution_mode=execution_mode,
+            statement_name=statement_name,
+            hidden=hidden,
         )
         response = self.get_response(cursor)
         if fetch:

--- a/dbt/adapters/confluent/connections.py
+++ b/dbt/adapters/confluent/connections.py
@@ -249,7 +249,6 @@ class ConfluentConnectionManager(SQLConnectionManager):
             else:
                 resolved_mode = ExecutionMode(connection.credentials.execution_mode)
 
-            prefix = connection.credentials.statement_name_prefix
             labels = [connection.credentials.statement_label]
             if hidden:
                 labels.append(HIDDEN_LABEL)

--- a/dbt/adapters/confluent/impl.py
+++ b/dbt/adapters/confluent/impl.py
@@ -172,7 +172,7 @@ class ConfluentAdapter(SQLAdapter):
 
         raise DbtDatabaseError(
             f"Statement '{statement_name}' still exists after {max_wait}s. "
-            f"Flink may still be stopping the job. Re-run or use `dbt retry`."
+            f"Flink may still be stopping the job."
         )
 
     @classmethod

--- a/dbt/adapters/confluent/impl.py
+++ b/dbt/adapters/confluent/impl.py
@@ -140,6 +140,42 @@ class ConfluentAdapter(SQLAdapter):
             name = f"{prefix}{project_name}-{model_name}{suffix}"
         return sanitize_statement_name(name)
 
+    @available
+    def delete_statement(self, statement_name: str) -> None:
+        """Delete a Flink statement by name and wait for deletion to complete.
+
+        Deletion of RUNNING statements is async (the job must stop first),
+        so we poll until the statement is gone (404).
+        No-op if the statement doesn't already exist.
+        """
+        import time
+
+        from confluent_sql.exceptions import StatementNotFoundError
+
+        conn = self.connections.get_thread_connection()
+        handle = conn.handle
+
+        # Send the delete request (no-op on 404).
+        handle.delete_statement(statement_name)
+
+        # Poll until the statement is actually gone, with exponential backoff.
+        max_wait = 60
+        waited = 0
+        attempt = 1
+        while waited < max_wait:
+            try:
+                handle.get_statement(statement_name)
+            except StatementNotFoundError:
+                return  # Successfully deleted
+            backoff = min(2**attempt, 15)
+            time.sleep(backoff)
+            waited += backoff
+            attempt += 1
+
+        logger.warning(
+            "Statement '%s' still exists after %ds — proceeding anyway", statement_name, max_wait
+        )
+
     @classmethod
     def convert_text_type(cls, agate_table: agate.Table, col_idx: int) -> str:
         return "STRING"

--- a/dbt/adapters/confluent/impl.py
+++ b/dbt/adapters/confluent/impl.py
@@ -156,19 +156,26 @@ class ConfluentAdapter(SQLAdapter):
         # Send the delete request (no-op on 404).
         handle.delete_statement(statement_name)
 
-        # Poll until the statement is actually gone, with exponential backoff.
+        # Check if the statement is already gone after the delete request.
+        try:
+            handle.get_statement(statement_name)
+        except StatementNotFoundError:
+            return  # Already gone (either deleted instantly or never existed)
+
+        # Statement still exists — it's being stopped. Poll until gone.
+        logger.info("Waiting for statement '%s' to be deleted...", statement_name)
         max_wait = 60
         waited = 0
         attempt = 1
         while waited < max_wait:
-            try:
-                handle.get_statement(statement_name)
-            except StatementNotFoundError:
-                return  # Successfully deleted
             backoff = min(2**attempt, 15)
             time.sleep(backoff)
             waited += backoff
             attempt += 1
+            try:
+                handle.get_statement(statement_name)
+            except StatementNotFoundError:
+                return  # Successfully deleted
 
         raise DbtDatabaseError(
             f"Statement '{statement_name}' still exists after {max_wait}s. "

--- a/dbt/adapters/confluent/impl.py
+++ b/dbt/adapters/confluent/impl.py
@@ -172,8 +172,9 @@ class ConfluentAdapter(SQLAdapter):
             waited += backoff
             attempt += 1
 
-        logger.warning(
-            "Statement '%s' still exists after %ds — proceeding anyway", statement_name, max_wait
+        raise DbtDatabaseError(
+            f"Statement '{statement_name}' still exists after {max_wait}s. "
+            f"Flink may still be stopping the job. Re-run or use `dbt retry`."
         )
 
     @classmethod

--- a/dbt/adapters/confluent/impl.py
+++ b/dbt/adapters/confluent/impl.py
@@ -13,6 +13,7 @@ from dbt.adapters.contracts.connection import AdapterResponse
 from dbt.adapters.contracts.relation import Policy
 from dbt.adapters.sql import SQLAdapter
 
+from .naming import sanitize_statement_name
 from .utils import fetch_from_cursor
 
 logger = logging.getLogger(__name__)
@@ -107,6 +108,7 @@ class ConfluentAdapter(SQLAdapter):
         limit: int | None = None,
         execution_mode: str | None = None,
         hidden: bool = False,
+        statement_name: str | None = None,
     ) -> tuple[AdapterResponse, "agate.Table"]:
         return self.connections.execute(
             sql=sql,
@@ -115,7 +117,28 @@ class ConfluentAdapter(SQLAdapter):
             limit=limit,
             execution_mode=execution_mode,
             hidden=hidden,
+            statement_name=statement_name,
         )
+
+    @available
+    def get_statement_name(
+        self,
+        model_name: str,
+        project_name: str,
+        suffix: str = "",
+        statement_name_override: str | None = None,
+    ) -> str:
+        """Build a deterministic, sanitized Flink statement name.
+
+        Called from Jinja macros via adapter.get_statement_name().
+        Returns the final name ready for the Flink API.
+        """
+        if statement_name_override:
+            name = f"{statement_name_override}{suffix}"
+        else:
+            prefix = self.config.credentials.statement_name_prefix
+            name = f"{prefix}{project_name}-{model_name}{suffix}"
+        return sanitize_statement_name(name)
 
     @classmethod
     def convert_text_type(cls, agate_table: agate.Table, col_idx: int) -> str:

--- a/dbt/adapters/confluent/impl.py
+++ b/dbt/adapters/confluent/impl.py
@@ -1,8 +1,10 @@
 import logging
 import re
+import time
 from dataclasses import dataclass, field
 
 import agate
+from confluent_sql.exceptions import StatementNotFoundError
 from dbt_common.events.contextvars import get_node_info
 from dbt_common.exceptions import CompilationError, DbtDatabaseError
 
@@ -148,10 +150,6 @@ class ConfluentAdapter(SQLAdapter):
         so we poll until the statement is gone (404).
         No-op if the statement doesn't already exist.
         """
-        import time
-
-        from confluent_sql.exceptions import StatementNotFoundError
-
         conn = self.connections.get_thread_connection()
         handle = conn.handle
 

--- a/dbt/adapters/confluent/naming.py
+++ b/dbt/adapters/confluent/naming.py
@@ -34,6 +34,11 @@ def sanitize_statement_name(name: str) -> str:
     # Strip leading hyphens — name must start with alphanumeric
     sanitized = sanitized.lstrip("-")
 
+    if not sanitized or not sanitized[0].isalnum():
+        raise ValueError(
+            f"Statement name must contain at least one alphanumeric character: '{original}'"
+        )
+
     if len(sanitized) > MAX_STATEMENT_NAME_LENGTH:
         hash_suffix = hashlib.md5(original.encode()).hexdigest()[:6]
         max_base = MAX_STATEMENT_NAME_LENGTH - 1 - len(hash_suffix)  # 1 for '-'

--- a/dbt/adapters/confluent/naming.py
+++ b/dbt/adapters/confluent/naming.py
@@ -1,0 +1,42 @@
+import hashlib
+import re
+
+MAX_STATEMENT_NAME_LENGTH = 72
+_VALID_CHARS_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+_ILLEGAL_CHARS_RE = re.compile(r"[^a-zA-Z0-9_-]")
+
+
+def sanitize_statement_name(name: str) -> str:
+    """Sanitize a Flink statement name.
+
+    - Replaces characters not in [a-zA-Z0-9_-] with '_'
+    - If any replacement occurred, appends a 4-char hash of the original
+      to avoid collisions (e.g. 'a.b' and 'a_b' won't clash)
+    - Truncates to 72 chars with a 6-char hash suffix if needed
+    """
+    sanitized = _ILLEGAL_CHARS_RE.sub("_", name)
+    if sanitized != name:
+        short_hash = hashlib.md5(name.encode()).hexdigest()[:4]
+        sanitized = f"{sanitized}-{short_hash}"
+
+    if len(sanitized) > MAX_STATEMENT_NAME_LENGTH:
+        hash_suffix = hashlib.md5(name.encode()).hexdigest()[:6]
+        max_base = MAX_STATEMENT_NAME_LENGTH - 1 - len(hash_suffix)  # 1 for '-'
+        sanitized = f"{sanitized[:max_base]}-{hash_suffix}"
+
+    return sanitized
+
+
+def validate_statement_name(name: str) -> None:
+    """Validate a statement name against Flink constraints.
+
+    Raises ValueError if the name is invalid.
+    """
+    if not name:
+        raise ValueError("Statement name cannot be empty")
+    if len(name) > MAX_STATEMENT_NAME_LENGTH:
+        raise ValueError(
+            f"Statement name exceeds {MAX_STATEMENT_NAME_LENGTH} char limit: '{name}'"
+        )
+    if not _VALID_CHARS_RE.match(name):
+        raise ValueError(f"Statement name contains illegal characters: '{name}'")

--- a/dbt/adapters/confluent/naming.py
+++ b/dbt/adapters/confluent/naming.py
@@ -2,7 +2,6 @@ import hashlib
 import re
 
 MAX_STATEMENT_NAME_LENGTH = 100
-_VALID_CHARS_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 _ILLEGAL_CHARS_RE = re.compile(r"[^a-z0-9-]")
 
 
@@ -17,17 +16,19 @@ def sanitize_statement_name(name: str) -> str:
     This function:
     - Lowercases the input
     - Replaces characters not in [a-z0-9-] (including underscores) with '-'
-    - If any replacement occurred, appends a 4-char hash of the original
+    - If any replacement occurred, appends a 6-char hash of the original
       to avoid collisions (e.g. 'a_b' and 'a.b' won't clash)
     - Strips leading hyphens (name must start with alphanumeric)
     - Truncates to 100 chars with a 6-char hash suffix if needed
     """
+    if not name:
+        raise ValueError("Statement name cannot be empty")
     original = name
     name = name.lower()
     sanitized = _ILLEGAL_CHARS_RE.sub("-", name)
 
     if sanitized != name:
-        short_hash = hashlib.md5(original.encode()).hexdigest()[:4]
+        short_hash = hashlib.md5(original.encode()).hexdigest()[:6]
         sanitized = f"{sanitized}-{short_hash}"
 
     # Strip leading hyphens — name must start with alphanumeric
@@ -39,21 +40,3 @@ def sanitize_statement_name(name: str) -> str:
         sanitized = f"{sanitized[:max_base]}-{hash_suffix}"
 
     return sanitized
-
-
-def validate_statement_name(name: str) -> None:
-    """Validate a statement name against Flink constraints.
-
-    Raises ValueError if the name is invalid.
-    """
-    if not name:
-        raise ValueError("Statement name cannot be empty")
-    if len(name) > MAX_STATEMENT_NAME_LENGTH:
-        raise ValueError(
-            f"Statement name exceeds {MAX_STATEMENT_NAME_LENGTH} char limit: '{name}'"
-        )
-    if not _VALID_CHARS_RE.match(name):
-        raise ValueError(
-            f"Statement name must contain only lowercase alphanumeric characters "
-            f"and hyphens, and start with an alphanumeric character: '{name}'"
-        )

--- a/dbt/adapters/confluent/naming.py
+++ b/dbt/adapters/confluent/naming.py
@@ -1,26 +1,40 @@
 import hashlib
 import re
 
-MAX_STATEMENT_NAME_LENGTH = 72
-_VALID_CHARS_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
-_ILLEGAL_CHARS_RE = re.compile(r"[^a-zA-Z0-9_-]")
+MAX_STATEMENT_NAME_LENGTH = 100
+_VALID_CHARS_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+_ILLEGAL_CHARS_RE = re.compile(r"[^a-z0-9-]")
 
 
 def sanitize_statement_name(name: str) -> str:
     """Sanitize a Flink statement name.
 
-    - Replaces characters not in [a-zA-Z0-9_-] with '_'
+    Flink statement names must:
+    - Contain only lowercase alphanumeric characters and hyphens
+    - Start with an alphanumeric character
+    - Be at most 100 characters long
+
+    This function:
+    - Lowercases the input
+    - Replaces characters not in [a-z0-9-] (including underscores) with '-'
     - If any replacement occurred, appends a 4-char hash of the original
-      to avoid collisions (e.g. 'a.b' and 'a_b' won't clash)
-    - Truncates to 72 chars with a 6-char hash suffix if needed
+      to avoid collisions (e.g. 'a_b' and 'a.b' won't clash)
+    - Strips leading hyphens (name must start with alphanumeric)
+    - Truncates to 100 chars with a 6-char hash suffix if needed
     """
-    sanitized = _ILLEGAL_CHARS_RE.sub("_", name)
+    original = name
+    name = name.lower()
+    sanitized = _ILLEGAL_CHARS_RE.sub("-", name)
+
     if sanitized != name:
-        short_hash = hashlib.md5(name.encode()).hexdigest()[:4]
+        short_hash = hashlib.md5(original.encode()).hexdigest()[:4]
         sanitized = f"{sanitized}-{short_hash}"
 
+    # Strip leading hyphens — name must start with alphanumeric
+    sanitized = sanitized.lstrip("-")
+
     if len(sanitized) > MAX_STATEMENT_NAME_LENGTH:
-        hash_suffix = hashlib.md5(name.encode()).hexdigest()[:6]
+        hash_suffix = hashlib.md5(original.encode()).hexdigest()[:6]
         max_base = MAX_STATEMENT_NAME_LENGTH - 1 - len(hash_suffix)  # 1 for '-'
         sanitized = f"{sanitized[:max_base]}-{hash_suffix}"
 
@@ -39,4 +53,7 @@ def validate_statement_name(name: str) -> None:
             f"Statement name exceeds {MAX_STATEMENT_NAME_LENGTH} char limit: '{name}'"
         )
     if not _VALID_CHARS_RE.match(name):
-        raise ValueError(f"Statement name contains illegal characters: '{name}'")
+        raise ValueError(
+            f"Statement name must contain only lowercase alphanumeric characters "
+            f"and hyphens, and start with an alphanumeric character: '{name}'"
+        )

--- a/dbt/include/confluent/macros/etc/statement.sql
+++ b/dbt/include/confluent/macros/etc/statement.sql
@@ -1,6 +1,7 @@
 -- This macro is customized so we can add a `limit` at call site to call `fetchmany(limit)`
 -- rather than `fetchall`, and also to get the `execution_mode` from the config, so that
--- we can instantiate a different cursor in `adapter.execute`
+-- we can instantiate a different cursor in `adapter.execute`.
+-- `statement_name` allows materializations to pass a deterministic Flink statement name.
 {%- macro statement(
   name=None,
   fetch_result=False,
@@ -8,7 +9,8 @@
   language='sql',
   limit=None,
   execution_mode=None,
-  hidden=False
+  hidden=False,
+  statement_name=None
 ) -%}
   {%- if execute: -%}
     {%- set compiled_code = caller() -%}
@@ -21,7 +23,7 @@
       {% if not execution_mode %}
         {% set execution_mode = config.get("execution_mode", None) %}
       {% endif %}
-      {%- set res, table = adapter.execute(compiled_code, auto_begin=auto_begin, fetch=fetch_result, execution_mode=execution_mode, limit=limit, hidden=hidden) -%}
+      {%- set res, table = adapter.execute(compiled_code, auto_begin=auto_begin, fetch=fetch_result, execution_mode=execution_mode, limit=limit, hidden=hidden, statement_name=statement_name) -%}
     {%- elif language == 'python' -%}
       {%- set res = submit_python_job(model, compiled_code) -%}
       {#-- TODO: What should table be for python models? --#}
@@ -36,3 +38,17 @@
 
   {%- endif -%}
 {%- endmacro %}
+
+
+{#-- Helper macro to derive a deterministic statement name from model context.
+     Calls the Python adapter method for sanitization/validation.
+     Pass a suffix (e.g. '-ddl') for secondary statements. --#}
+{%- macro get_statement_name(suffix='') -%}
+  {%- set custom_name = config.get('statement_name', none) -%}
+  {{ adapter.get_statement_name(
+       model_name=model.name,
+       project_name=project_name,
+       suffix=suffix,
+       statement_name_override=custom_name
+  ) | trim }}
+{%- endmacro -%}

--- a/dbt/include/confluent/macros/materializations/models/helpers.sql
+++ b/dbt/include/confluent/macros/materializations/models/helpers.sql
@@ -2,7 +2,6 @@
   {# Delete an existing Flink statement by name so we can re-create it.
      No-op if the statement doesn't exist (confluent-sql handles 404). #}
   {% if execute %}
-    {{ log("Deleting existing statement: " ~ statement_name, info=True) }}
     {% do adapter.delete_statement(statement_name) %}
   {% endif %}
 {% endmacro %}

--- a/dbt/include/confluent/macros/materializations/models/helpers.sql
+++ b/dbt/include/confluent/macros/materializations/models/helpers.sql
@@ -1,3 +1,13 @@
+{% macro delete_statement_if_exists(statement_name) %}
+  {# Delete an existing Flink statement by name so we can re-create it.
+     No-op if the statement doesn't exist (confluent-sql handles 404). #}
+  {% if execute %}
+    {{ log("Deleting existing statement: " ~ statement_name, info=True) }}
+    {% do adapter.delete_statement(statement_name) %}
+  {% endif %}
+{% endmacro %}
+
+
 {% macro skip_or_drop_existing(existing_relation, target_relation, has_select_query=true) %}
   {# If the relation already exists, either drop it (on --full-refresh) or skip.
      Returns true if the caller should skip (relation exists and no full refresh).
@@ -6,6 +16,8 @@
                        false if it's column definitions (streaming_source). #}
   {% if existing_relation %}
     {% if should_full_refresh() %}
+      {{ delete_statement_if_exists(get_statement_name()) }}
+      {{ delete_statement_if_exists(get_statement_name('-ddl')) }}
       {{ drop_relation_if_exists(existing_relation) }}
       {{ return(false) }}
     {% else %}

--- a/dbt/include/confluent/macros/materializations/models/helpers.sql
+++ b/dbt/include/confluent/macros/materializations/models/helpers.sql
@@ -33,6 +33,12 @@
       {% endif %}
       {{ return(true) }}
     {% endif %}
+  {% else %}
+    {# No relation exists, but orphaned Flink statements may linger if the table
+       was dropped without deleting its statements (e.g. external cleanup).
+       Delete them so the materialization can create fresh ones. #}
+    {{ delete_statement_if_exists(get_statement_name()) }}
+    {{ delete_statement_if_exists(get_statement_name('-ddl')) }}
   {% endif %}
   {{ return(false) }}
 {% endmacro %}

--- a/dbt/include/confluent/macros/materializations/models/streaming_source.sql
+++ b/dbt/include/confluent/macros/materializations/models/streaming_source.sql
@@ -27,8 +27,9 @@
   -- See comment above about calling hooks
   {{ run_hooks(pre_hooks, inside_transaction=True) }}
 
-  -- Create the table
-  {% call statement('main', execution_mode="streaming_ddl") -%}
+  -- Create the connector-backed table (long-running — gets primary name).
+  {% call statement('main', execution_mode="streaming_ddl",
+                    statement_name=get_statement_name()) -%}
     CREATE TABLE {{ target_relation }}
     ( {{ sql }})
     WITH (

--- a/dbt/include/confluent/macros/materializations/models/streaming_table.sql
+++ b/dbt/include/confluent/macros/materializations/models/streaming_table.sql
@@ -26,8 +26,9 @@
   -- See comment above about calling hooks
   {{ run_hooks(pre_hooks, inside_transaction=True) }}
 
-  -- First, create the table.
-  {% call statement('main', execution_mode="streaming_ddl") -%}
+  -- First, create the table (transient DDL — gets '-ddl' suffix).
+  {% call statement('main', execution_mode="streaming_ddl",
+                    statement_name=get_statement_name('-ddl')) -%}
     create table {{ target_relation }}
     {{ get_assert_columns_equivalent(sql) }}
     {{ get_table_columns_and_constraints() }}
@@ -40,8 +41,9 @@
     {% endif %}
   {%- endcall -%}
 
-  -- Then insert data into it:
-  {%- call statement('insert', execution_mode="streaming_query") -%}
+  -- Then insert data into it (long-running — gets primary name).
+  {%- call statement('insert', execution_mode="streaming_query",
+                     statement_name=get_statement_name()) -%}
     INSERT INTO {{ target_relation }} {{ sql }}
   {%- endcall -%}
 

--- a/dbt/include/confluent/macros/materializations/models/table.sql
+++ b/dbt/include/confluent/macros/materializations/models/table.sql
@@ -15,7 +15,7 @@
   {{ run_hooks(pre_hooks, inside_transaction=True) }}
 
   -- build model
-  {% call statement('main') -%}
+  {% call statement('main', statement_name=get_statement_name()) -%}
     {{ get_create_table_as_sql(False, target_relation, sql) }}
   {%- endcall %}
 

--- a/dbt/include/confluent/macros/materializations/models/view.sql
+++ b/dbt/include/confluent/macros/materializations/models/view.sql
@@ -11,7 +11,7 @@
   {{ run_hooks(pre_hooks, inside_transaction=True) }}
 
   -- build model
-  {% call statement('main') -%}
+  {% call statement('main', statement_name=get_statement_name()) -%}
     {{ get_create_view_as_sql(target_relation, sql) }}
   {%- endcall %}
 

--- a/dbt/include/confluent/macros/materializations/models/view.sql
+++ b/dbt/include/confluent/macros/materializations/models/view.sql
@@ -4,7 +4,8 @@
 
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
-  -- drop the relation if it exists already in the database
+  -- delete existing statement and drop the relation if it exists already
+  {{ delete_statement_if_exists(get_statement_name()) }}
   {{ drop_relation_if_exists(existing_relation) }}
 
   -- `BEGIN` happens here:

--- a/dbt/include/confluent/profile_template.yml
+++ b/dbt/include/confluent/profile_template.yml
@@ -30,9 +30,9 @@ prompts:
     type: "string"
     default: 'streaming_query'
   statement_name_prefix:
-    hint: "A prefix to prepend to each statement name"
+    hint: "Prefix for statement names (project name is appended automatically)"
     type: "string"
-    default: "dbt-confluent-"
+    default: "dbt-"
   statement_label:
     hint: "A user label applied to all statements"
     type: "string"

--- a/tests/functional/adapter/fixtures.py
+++ b/tests/functional/adapter/fixtures.py
@@ -73,4 +73,6 @@ class ConfluentFixtures:
         with project.adapter.connection_named("cleanup"):
             conn = project.adapter.connections.get_thread_connection()
             for statement in conn.handle.list_statements(label=label):
-                conn.handle.delete_statement(statement)
+                # Use the adapter helper which polls until deletion completes,
+                # because deleting RUNNING statements is async.
+                project.adapter.delete_statement(statement.name)

--- a/tests/functional/adapter/test_streaming_table.py
+++ b/tests/functional/adapter/test_streaming_table.py
@@ -1,5 +1,3 @@
-from textwrap import dedent
-
 import pytest
 from confluent_sql.exceptions import StatementNotFoundError
 
@@ -31,6 +29,15 @@ WATERMARK FOR order_time AS order_time - INTERVAL '5' SECOND,
 PRIMARY KEY(`order_id`) NOT ENFORCED
 """
 
+MY_CUSTOM_NAMED_TABLE = """
+{{ config(
+    materialized='streaming_table',
+    statement_name='my-custom-insert',
+    with={'changelog.mode': 'append'},
+) }}
+select order_id, price from {{ ref('my_streaming_source') }}
+"""
+
 MODELS_YML = """
 models:
   - name: my_streaming_table
@@ -45,6 +52,12 @@ models:
         data_type: decimal(10,2)
       - name: order_time
         data_type: timestamp(3)
+  - name: my_custom_named_table
+    columns:
+      - name: order_id
+        data_type: bigint
+      - name: price
+        data_type: decimal(10,2)
 """
 
 
@@ -60,6 +73,7 @@ class TestStreamingTable(ConfluentFixtures):
         yield {
             "my_streaming_source.sql": MY_STREAMING_SOURCE,
             "my_streaming_table.sql": MY_STREAMING_TABLE,
+            "my_custom_named_table.sql": MY_CUSTOM_NAMED_TABLE,
             "models.yml": MODELS_YML,
         }
 
@@ -78,18 +92,19 @@ class TestStreamingTable(ConfluentFixtures):
             for stmt in conn.handle.list_statements(label=label):
                 print(f"Deleting: {stmt.name}")
                 project.adapter.delete_statement(stmt.name)
+        project.run_sql("drop table if exists my_custom_named_table")
         project.run_sql("drop table if exists my_streaming_table")
         project.run_sql("drop table if exists my_streaming_source")
 
     def test_materialized_source(self, project, run_dbt_results):
-        assert run_dbt_results[0].node.name == "my_streaming_source"
-        assert run_dbt_results[1].node.name == "my_streaming_table"
+        result_names = {r.node.name for r in run_dbt_results}
+        assert {"my_streaming_source", "my_streaming_table", "my_custom_named_table"} == result_names
         relation = relation_from_name(project.adapter, "my_streaming_table")
         result = project.run_sql(f"select * from {relation}", fetch="one")
         assert len(result[0]) == 3
 
         catalog = run_dbt(["docs", "generate"])
-        assert len(catalog.nodes) == 2
+        assert len(catalog.nodes) == 3
         assert len(catalog.sources) == 0
 
     def test_deterministic_statement_names(self, project, run_dbt_results):
@@ -112,3 +127,25 @@ class TestStreamingTable(ConfluentFixtures):
             except StatementNotFoundError:
                 pytest.fail(f"Expected Flink statement '{name}' to exist but it was not found")
             assert stmt is not None, f"Statement '{name}' should exist"
+
+    def test_custom_statement_name(self, project, run_dbt_results):
+        """Verify that config(statement_name='...') overrides the default naming.
+
+        my_custom_named_table uses statement_name='my-custom-insert', so
+        its long-running INSERT statement should exist under that name."""
+        adapter = project.adapter
+        expected_name = adapter.get_statement_name(
+            model_name="my_custom_named_table",
+            project_name=self.NAME,
+            statement_name_override="my-custom-insert",
+        )
+
+        with adapter.connection_named("check_custom"):
+            conn = adapter.connections.get_thread_connection()
+            try:
+                stmt = conn.handle.get_statement(expected_name)
+            except StatementNotFoundError:
+                pytest.fail(
+                    f"Expected statement '{expected_name}' from config override, but not found"
+                )
+            assert stmt is not None

--- a/tests/functional/adapter/test_streaming_table.py
+++ b/tests/functional/adapter/test_streaming_table.py
@@ -90,7 +90,6 @@ class TestStreamingTable(ConfluentFixtures):
         with project.adapter.connection_named("cleanup"):
             conn = project.adapter.connections.get_thread_connection()
             for stmt in conn.handle.list_statements(label=label):
-                print(f"Deleting: {stmt.name}")
                 project.adapter.delete_statement(stmt.name)
         project.run_sql("drop table if exists my_custom_named_table")
         project.run_sql("drop table if exists my_streaming_table")

--- a/tests/functional/adapter/test_streaming_table.py
+++ b/tests/functional/adapter/test_streaming_table.py
@@ -98,7 +98,11 @@ class TestStreamingTable(ConfluentFixtures):
 
     def test_materialized_source(self, project, run_dbt_results):
         result_names = {r.node.name for r in run_dbt_results}
-        assert {"my_streaming_source", "my_streaming_table", "my_custom_named_table"} == result_names
+        assert {
+            "my_streaming_source",
+            "my_streaming_table",
+            "my_custom_named_table",
+        } == result_names
         relation = relation_from_name(project.adapter, "my_streaming_table")
         result = project.run_sql(f"select * from {relation}", fetch="one")
         assert len(result[0]) == 3

--- a/tests/functional/adapter/test_streaming_table.py
+++ b/tests/functional/adapter/test_streaming_table.py
@@ -1,6 +1,7 @@
 from textwrap import dedent
 
 import pytest
+from confluent_sql.exceptions import StatementNotFoundError
 
 from dbt.tests.util import relation_from_name, run_dbt
 from tests.functional.adapter.fixtures import ConfluentFixtures
@@ -48,6 +49,12 @@ models:
 
 
 class TestStreamingTable(ConfluentFixtures):
+    NAME = "streaming"
+
+    @pytest.fixture(scope="class")
+    def run_dbt_results(self, project):
+        return run_dbt(["run"])
+
     @pytest.fixture(scope="class", autouse=True)
     def models(self):
         yield {
@@ -57,15 +64,26 @@ class TestStreamingTable(ConfluentFixtures):
         }
 
     @pytest.fixture(autouse=True)
-    def custom_clean_up(self, project):
+    def clean_up(self, project, dbt_profile_data):
+        """Override base clean_up so statements survive across tests in this class."""
         yield
-        project.run_sql("drop table if exists my_streaming_source")
-        project.run_sql("drop table if exists my_streaming_table")
 
-    def test_materialized_source(self, project):
-        results = run_dbt(["run"])
-        assert results[0].node.name == "my_streaming_source"
-        assert results[1].node.name == "my_streaming_table"
+    @pytest.fixture(autouse=True, scope="class")
+    def class_clean_up(self, project, dbt_profile_data):
+        """Delete statements and tables once after all tests in the class."""
+        yield
+        label = dbt_profile_data["test"]["outputs"]["default"]["statement_label"]
+        with project.adapter.connection_named("cleanup"):
+            conn = project.adapter.connections.get_thread_connection()
+            for stmt in conn.handle.list_statements(label=label):
+                print(f"Deleting: {stmt.name}")
+                project.adapter.delete_statement(stmt.name)
+        project.run_sql("drop table if exists my_streaming_table")
+        project.run_sql("drop table if exists my_streaming_source")
+
+    def test_materialized_source(self, project, run_dbt_results):
+        assert run_dbt_results[0].node.name == "my_streaming_source"
+        assert run_dbt_results[1].node.name == "my_streaming_table"
         relation = relation_from_name(project.adapter, "my_streaming_table")
         result = project.run_sql(f"select * from {relation}", fetch="one")
         assert len(result[0]) == 3
@@ -73,3 +91,24 @@ class TestStreamingTable(ConfluentFixtures):
         catalog = run_dbt(["docs", "generate"])
         assert len(catalog.nodes) == 2
         assert len(catalog.sources) == 0
+
+    def test_deterministic_statement_names(self, project, run_dbt_results):
+        """After dbt run, the long-running streaming INSERT statement should
+        exist with a deterministic name derived from project and model names.
+
+        Only the streaming_table INSERT is guaranteed to still be RUNNING;
+        the DDL statement and the streaming_source statement complete
+        immediately and may be auto-cleaned by Flink before we check."""
+        adapter = project.adapter
+        name = adapter.get_statement_name(
+            model_name="my_streaming_table",
+            project_name=self.NAME,
+        )
+
+        with adapter.connection_named("check_statements"):
+            conn = adapter.connections.get_thread_connection()
+            try:
+                stmt = conn.handle.get_statement(name)
+            except StatementNotFoundError:
+                pytest.fail(f"Expected Flink statement '{name}' to exist but it was not found")
+            assert stmt is not None, f"Statement '{name}' should exist"

--- a/tests/unit/test_naming.py
+++ b/tests/unit/test_naming.py
@@ -11,81 +11,98 @@ from dbt.adapters.confluent.naming import (
 
 class TestSanitizeStatementName:
     def test_clean_name_unchanged(self):
-        assert sanitize_statement_name("dbt-myproject-my_model") == "dbt-myproject-my_model"
+        assert sanitize_statement_name("dbt-myproject-my-model") == "dbt-myproject-my-model"
 
-    def test_alphanumeric_and_hyphens_preserved(self):
-        assert sanitize_statement_name("abc-123_DEF") == "abc-123_DEF"
+    def test_lowercased(self):
+        assert sanitize_statement_name("dbt-MyProject-Model") == "dbt-myproject-model"
+
+    def test_underscores_replaced_with_hash(self):
+        result = sanitize_statement_name("dbt-proj-my_model")
+        assert "_" not in result
+        assert result.startswith("dbt-proj-my-model-")
+        assert len(result.split("-")[-1]) == 4  # 4-char hash
 
     def test_dots_replaced_with_hash(self):
         result = sanitize_statement_name("dbt-proj-my.model")
         assert "." not in result
-        # Should have a hash suffix to avoid collisions
-        assert result.startswith("dbt-proj-my_model-")
-        assert len(result.split("-")[-1]) == 4  # 4-char hash
+        assert result.startswith("dbt-proj-my-model-")
 
     def test_different_originals_get_different_hashes(self):
         """Two names that sanitize to the same base must get different hashes."""
         a = sanitize_statement_name("dbt-a.b")
-        b = sanitize_statement_name("dbt-a:b")
-        # Both have illegal chars replaced with '_', but originals differ
-        # so their hashes should differ
+        b = sanitize_statement_name("dbt-a_b")
         assert a != b
 
-    def test_same_sanitized_name_is_stable(self):
-        """Same input always produces the same output."""
-        name = "dbt-proj-model.v2"
+    def test_same_input_is_stable(self):
+        name = "dbt-proj-model_v2"
         assert sanitize_statement_name(name) == sanitize_statement_name(name)
 
     def test_no_collision_with_clean_name(self):
-        """A name with illegal chars should not collide with its underscore equivalent."""
+        """A name with illegal chars should not collide with its hyphen equivalent."""
         dirty = sanitize_statement_name("dbt-a.b")
-        clean = sanitize_statement_name("dbt-a_b")
+        clean = sanitize_statement_name("dbt-a-b")
         assert dirty != clean
 
+    def test_leading_hyphens_stripped(self):
+        result = sanitize_statement_name("--dbt-model")
+        assert result[0].isalnum()
+
+    def test_leading_illegal_chars_stripped(self):
+        result = sanitize_statement_name("__dbt-model")
+        assert result[0].isalnum()
+
     def test_truncation_when_too_long(self):
-        long_name = "dbt-" + "a" * 100
+        long_name = "dbt-" + "a" * 120
         result = sanitize_statement_name(long_name)
         assert len(result) <= MAX_STATEMENT_NAME_LENGTH
 
     def test_truncation_preserves_hash(self):
-        long_name = "dbt-" + "a" * 100
+        long_name = "dbt-" + "a" * 120
         result = sanitize_statement_name(long_name)
-        # Should end with a hash suffix
         parts = result.rsplit("-", 1)
         assert len(parts) == 2
         assert len(parts[1]) == 6  # 6-char hash for truncation
 
     def test_truncation_with_illegal_chars(self):
-        """Name with both illegal chars and excessive length."""
-        long_name = "dbt-" + "a.b" * 50
+        long_name = "dbt-" + "a_b" * 50
         result = sanitize_statement_name(long_name)
         assert len(result) <= MAX_STATEMENT_NAME_LENGTH
-        assert all(c in "abcdefghijklmnopqrstuvwxyz0123456789_-" for c in result)
+        assert all(c in "abcdefghijklmnopqrstuvwxyz0123456789-" for c in result)
 
-    def test_exactly_72_chars_not_truncated(self):
-        name = "a" * 72
+    def test_exactly_max_length_not_truncated(self):
+        name = "a" * MAX_STATEMENT_NAME_LENGTH
         result = sanitize_statement_name(name)
         assert result == name
-        assert len(result) == 72
+        assert len(result) == MAX_STATEMENT_NAME_LENGTH
 
-    def test_73_chars_truncated(self):
-        name = "a" * 73
+    def test_one_over_max_truncated(self):
+        name = "a" * (MAX_STATEMENT_NAME_LENGTH + 1)
         result = sanitize_statement_name(name)
-        assert len(result) <= 72
+        assert len(result) <= MAX_STATEMENT_NAME_LENGTH
 
     def test_empty_string(self):
         result = sanitize_statement_name("")
         assert result == ""
 
     def test_spaces_replaced(self):
-        result = sanitize_statement_name("dbt my model")
+        result = sanitize_statement_name("dbt-my-model")
         assert " " not in result
-        assert result.startswith("dbt_my_model-")
+
+    def test_realistic_name(self):
+        """Test a realistic dbt model name with underscores."""
+        result = sanitize_statement_name("dbt-my_project-stg_orders_v2")
+        assert "_" not in result
+        assert result[0].isalnum()
+        assert len(result) <= MAX_STATEMENT_NAME_LENGTH
+
+    def test_suffix_preserved(self):
+        result = sanitize_statement_name("dbt-myproject-mymodel-ddl")
+        assert result == "dbt-myproject-mymodel-ddl"
 
 
 class TestValidateStatementName:
     def test_valid_name(self):
-        validate_statement_name("dbt-myproject-my_model")
+        validate_statement_name("dbt-myproject-my-model")
 
     def test_empty_name_raises(self):
         with pytest.raises(ValueError, match="cannot be empty"):
@@ -93,15 +110,27 @@ class TestValidateStatementName:
 
     def test_too_long_raises(self):
         with pytest.raises(ValueError, match="exceeds"):
-            validate_statement_name("a" * 73)
+            validate_statement_name("a" * (MAX_STATEMENT_NAME_LENGTH + 1))
 
-    def test_exactly_72_valid(self):
-        validate_statement_name("a" * 72)
+    def test_exactly_max_valid(self):
+        validate_statement_name("a" * MAX_STATEMENT_NAME_LENGTH)
 
-    def test_illegal_chars_raises(self):
-        with pytest.raises(ValueError, match="illegal characters"):
+    def test_uppercase_raises(self):
+        with pytest.raises(ValueError, match="lowercase"):
+            validate_statement_name("dbt-Model")
+
+    def test_underscore_raises(self):
+        with pytest.raises(ValueError, match="lowercase"):
+            validate_statement_name("dbt-my_model")
+
+    def test_dots_raises(self):
+        with pytest.raises(ValueError, match="lowercase"):
             validate_statement_name("dbt.model")
 
+    def test_leading_hyphen_raises(self):
+        with pytest.raises(ValueError, match="start with an alphanumeric"):
+            validate_statement_name("-dbt-model")
+
     def test_spaces_raises(self):
-        with pytest.raises(ValueError, match="illegal characters"):
+        with pytest.raises(ValueError, match="lowercase"):
             validate_statement_name("dbt model")

--- a/tests/unit/test_naming.py
+++ b/tests/unit/test_naming.py
@@ -15,6 +15,10 @@ class TestSanitizeStatementName:
     def test_lowercased(self):
         assert sanitize_statement_name("dbt-MyProject-Model") == "dbt-myproject-model"
 
+    def test_only_hyphens_raises(self):
+        with pytest.raises(ValueError, match="at least one alphanumeric"):
+            sanitize_statement_name("-------")
+
     def test_underscores_replaced_with_hash(self):
         result = sanitize_statement_name("dbt-proj-my_model")
         assert "_" not in result

--- a/tests/unit/test_naming.py
+++ b/tests/unit/test_naming.py
@@ -84,7 +84,7 @@ class TestSanitizeStatementName:
             sanitize_statement_name("")
 
     def test_spaces_replaced(self):
-        result = sanitize_statement_name("dbt-my-model")
+        result = sanitize_statement_name("dbt-my model")
         assert " " not in result
 
     def test_realistic_name(self):

--- a/tests/unit/test_naming.py
+++ b/tests/unit/test_naming.py
@@ -1,0 +1,107 @@
+"""Unit tests for statement name sanitization and validation."""
+
+import pytest
+
+from dbt.adapters.confluent.naming import (
+    MAX_STATEMENT_NAME_LENGTH,
+    sanitize_statement_name,
+    validate_statement_name,
+)
+
+
+class TestSanitizeStatementName:
+    def test_clean_name_unchanged(self):
+        assert sanitize_statement_name("dbt-myproject-my_model") == "dbt-myproject-my_model"
+
+    def test_alphanumeric_and_hyphens_preserved(self):
+        assert sanitize_statement_name("abc-123_DEF") == "abc-123_DEF"
+
+    def test_dots_replaced_with_hash(self):
+        result = sanitize_statement_name("dbt-proj-my.model")
+        assert "." not in result
+        # Should have a hash suffix to avoid collisions
+        assert result.startswith("dbt-proj-my_model-")
+        assert len(result.split("-")[-1]) == 4  # 4-char hash
+
+    def test_different_originals_get_different_hashes(self):
+        """Two names that sanitize to the same base must get different hashes."""
+        a = sanitize_statement_name("dbt-a.b")
+        b = sanitize_statement_name("dbt-a:b")
+        # Both have illegal chars replaced with '_', but originals differ
+        # so their hashes should differ
+        assert a != b
+
+    def test_same_sanitized_name_is_stable(self):
+        """Same input always produces the same output."""
+        name = "dbt-proj-model.v2"
+        assert sanitize_statement_name(name) == sanitize_statement_name(name)
+
+    def test_no_collision_with_clean_name(self):
+        """A name with illegal chars should not collide with its underscore equivalent."""
+        dirty = sanitize_statement_name("dbt-a.b")
+        clean = sanitize_statement_name("dbt-a_b")
+        assert dirty != clean
+
+    def test_truncation_when_too_long(self):
+        long_name = "dbt-" + "a" * 100
+        result = sanitize_statement_name(long_name)
+        assert len(result) <= MAX_STATEMENT_NAME_LENGTH
+
+    def test_truncation_preserves_hash(self):
+        long_name = "dbt-" + "a" * 100
+        result = sanitize_statement_name(long_name)
+        # Should end with a hash suffix
+        parts = result.rsplit("-", 1)
+        assert len(parts) == 2
+        assert len(parts[1]) == 6  # 6-char hash for truncation
+
+    def test_truncation_with_illegal_chars(self):
+        """Name with both illegal chars and excessive length."""
+        long_name = "dbt-" + "a.b" * 50
+        result = sanitize_statement_name(long_name)
+        assert len(result) <= MAX_STATEMENT_NAME_LENGTH
+        assert all(c in "abcdefghijklmnopqrstuvwxyz0123456789_-" for c in result)
+
+    def test_exactly_72_chars_not_truncated(self):
+        name = "a" * 72
+        result = sanitize_statement_name(name)
+        assert result == name
+        assert len(result) == 72
+
+    def test_73_chars_truncated(self):
+        name = "a" * 73
+        result = sanitize_statement_name(name)
+        assert len(result) <= 72
+
+    def test_empty_string(self):
+        result = sanitize_statement_name("")
+        assert result == ""
+
+    def test_spaces_replaced(self):
+        result = sanitize_statement_name("dbt my model")
+        assert " " not in result
+        assert result.startswith("dbt_my_model-")
+
+
+class TestValidateStatementName:
+    def test_valid_name(self):
+        validate_statement_name("dbt-myproject-my_model")
+
+    def test_empty_name_raises(self):
+        with pytest.raises(ValueError, match="cannot be empty"):
+            validate_statement_name("")
+
+    def test_too_long_raises(self):
+        with pytest.raises(ValueError, match="exceeds"):
+            validate_statement_name("a" * 73)
+
+    def test_exactly_72_valid(self):
+        validate_statement_name("a" * 72)
+
+    def test_illegal_chars_raises(self):
+        with pytest.raises(ValueError, match="illegal characters"):
+            validate_statement_name("dbt.model")
+
+    def test_spaces_raises(self):
+        with pytest.raises(ValueError, match="illegal characters"):
+            validate_statement_name("dbt model")

--- a/tests/unit/test_naming.py
+++ b/tests/unit/test_naming.py
@@ -1,11 +1,10 @@
-"""Unit tests for statement name sanitization and validation."""
+"""Unit tests for statement name sanitization."""
 
 import pytest
 
 from dbt.adapters.confluent.naming import (
     MAX_STATEMENT_NAME_LENGTH,
     sanitize_statement_name,
-    validate_statement_name,
 )
 
 
@@ -20,7 +19,7 @@ class TestSanitizeStatementName:
         result = sanitize_statement_name("dbt-proj-my_model")
         assert "_" not in result
         assert result.startswith("dbt-proj-my-model-")
-        assert len(result.split("-")[-1]) == 4  # 4-char hash
+        assert len(result.split("-")[-1]) == 6  # 6-char hash
 
     def test_dots_replaced_with_hash(self):
         result = sanitize_statement_name("dbt-proj-my.model")
@@ -80,9 +79,9 @@ class TestSanitizeStatementName:
         result = sanitize_statement_name(name)
         assert len(result) <= MAX_STATEMENT_NAME_LENGTH
 
-    def test_empty_string(self):
-        result = sanitize_statement_name("")
-        assert result == ""
+    def test_empty_string_raises(self):
+        with pytest.raises(ValueError, match="cannot be empty"):
+            sanitize_statement_name("")
 
     def test_spaces_replaced(self):
         result = sanitize_statement_name("dbt-my-model")
@@ -98,39 +97,3 @@ class TestSanitizeStatementName:
     def test_suffix_preserved(self):
         result = sanitize_statement_name("dbt-myproject-mymodel-ddl")
         assert result == "dbt-myproject-mymodel-ddl"
-
-
-class TestValidateStatementName:
-    def test_valid_name(self):
-        validate_statement_name("dbt-myproject-my-model")
-
-    def test_empty_name_raises(self):
-        with pytest.raises(ValueError, match="cannot be empty"):
-            validate_statement_name("")
-
-    def test_too_long_raises(self):
-        with pytest.raises(ValueError, match="exceeds"):
-            validate_statement_name("a" * (MAX_STATEMENT_NAME_LENGTH + 1))
-
-    def test_exactly_max_valid(self):
-        validate_statement_name("a" * MAX_STATEMENT_NAME_LENGTH)
-
-    def test_uppercase_raises(self):
-        with pytest.raises(ValueError, match="lowercase"):
-            validate_statement_name("dbt-Model")
-
-    def test_underscore_raises(self):
-        with pytest.raises(ValueError, match="lowercase"):
-            validate_statement_name("dbt-my_model")
-
-    def test_dots_raises(self):
-        with pytest.raises(ValueError, match="lowercase"):
-            validate_statement_name("dbt.model")
-
-    def test_leading_hyphen_raises(self):
-        with pytest.raises(ValueError, match="start with an alphanumeric"):
-            validate_statement_name("-dbt-model")
-
-    def test_spaces_raises(self):
-        with pytest.raises(ValueError, match="lowercase"):
-            validate_statement_name("dbt model")


### PR DESCRIPTION
Fixes #29, partially addresses #30.

Replaces UUID-based Flink statement names with deterministic names derived from the dbt project and model: `dbt-{project}-{model}`. For `streaming_table`, the DDL statement gets a `-ddl` suffix. Users can override the name per model via `config(statement_name='...')`.

This is the foundation for orphan cleanup (#30), idempotent re-runs (#32), and crash recovery (#33) — you can now predict a statement's name without querying Flink. On `--full-refresh`, existing statements are explicitly deleted before dropping and recreating the table, which addresses the orphaned statement problem described in #30.

- **`naming.py`** (new): Sanitizes names to comply with Flink constraints (lowercase alphanumeric + hyphens, max 100 chars). Appends a 6-char MD5 hash when illegal characters are replaced to avoid collisions.
- **`impl.py`**: New `get_statement_name()` (callable from Jinja) and `delete_statement()` (polls until async deletion completes, raises `DbtDatabaseError` on timeout).
- **`connections.py`**: Threads `statement_name` through `execute()` / `add_query()`. Falls back to UUID for metadata queries. Reuses the same name on retry instead of generating a new one.
- **Macros**: All materializations (`table`, `view`, `streaming_table`, `streaming_source`) pass deterministic names. `skip_or_drop_existing()` deletes statements on `--full-refresh` and cleans up orphans when no relation exists.
- **Default prefix changed** from `dbt-confluent-` to `dbt-`.