### PR TITLE
Release v0.2.0 changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,18 @@
-# Changelog for dbt-confluent
+dbt-confluent 0.2.0 (2026-04-22)
+
+# Features
+
+- Removed `materialized_view` materialization (use `table`, see "Not Supported" section in MATERIALIZATIONS.md)
+- Schema drift detection configurable via "on_schema_drift: 'fail' | 'ignore'". See MATERIALIZATIONS.md
+- Use deterministic names for Flink statements, laying the groundwork for future orphan cleanup, idempotent re-runs, and crash recovery. The default `statement_name_prefix` changed from `dbt-confluent-` to `dbt-`. ([#29](https://github.com/confluentinc/dbt-confluent/issues/29))
+- Mark internal/metadata queries with the hidden label so they are filtered by default in the Confluent UI ([#39](https://github.com/confluentinc/dbt-confluent/issues/39))
+- Add custom endpoint configuration for private and other non-standard cluster urls ([#44](https://github.com/confluentinc/dbt-confluent/issues/44))
+
+# Bugfixes
+
+- Delete existing statements before re-submitting with the same deterministic name on `--full-refresh` ([#29](https://github.com/confluentinc/dbt-confluent/issues/29))
+- Render model-level `PRIMARY KEY` constraints with the column list before the constraint expression (e.g. `PRIMARY KEY (col1, col2) NOT ENFORCED`), so Flink accepts the generated DDL. ([#31](https://github.com/confluentinc/dbt-confluent/issues/31))
+
+# Misc
+
+- Update to confluent-sql 0.3 ([#40](https://github.com/confluentinc/dbt-confluent/issues/40))

--- a/changes/+ci.trivial.md
+++ b/changes/+ci.trivial.md
@@ -1,1 +1,0 @@
-Make CI steps run in parallel

--- a/changes/+naming-cleanup.trivial.md
+++ b/changes/+naming-cleanup.trivial.md
@@ -1,1 +1,0 @@
-Follow-up cleanups from PR #49 review: drop redundant trailing hash in oversized sanitized statement names, report actual elapsed time on `delete_statement` timeout, and remove `httpx.TimeoutException` from retryable exceptions.

--- a/changes/+towncrier-setup.misc
+++ b/changes/+towncrier-setup.misc
@@ -1,1 +1,0 @@
-Added towncrier dependency and setup

--- a/changes/29.bugfix.md
+++ b/changes/29.bugfix.md
@@ -1,1 +1,0 @@
-Delete existing statements before re-submitting with the same deterministic name on `--full-refresh`

--- a/changes/29.feature.md
+++ b/changes/29.feature.md
@@ -1,1 +1,0 @@
-Use deterministic names for Flink statements, laying the groundwork for future orphan cleanup, idempotent re-runs, and crash recovery. The default `statement_name_prefix` changed from `dbt-confluent-` to `dbt-`.

--- a/changes/31.bugfix.md
+++ b/changes/31.bugfix.md
@@ -1,1 +1,0 @@
-Render model-level `PRIMARY KEY` constraints with the column list before the constraint expression (e.g. `PRIMARY KEY (col1, col2) NOT ENFORCED`), so Flink accepts the generated DDL.

--- a/changes/39.feature.md
+++ b/changes/39.feature.md
@@ -1,1 +1,0 @@
-Mark internal/metadata queries with the hidden label so they are filtered by default in the Confluent UI

--- a/changes/40.misc.md
+++ b/changes/40.misc.md
@@ -1,1 +1,0 @@
-Update to confluent-sql 0.3

--- a/changes/44.feature.md
+++ b/changes/44.feature.md
@@ -1,1 +1,0 @@
-Add custom endpoint configuration for private and other non-standard cluster urls


### PR DESCRIPTION
Run `towncrier build` to compact the newsfragments into CHANGELOG.md, with some manual editing