### PR TITLE
Change confluent-sql default http timeout

### DIFF
--- a/changes/+http-timeout.bugfix.md
+++ b/changes/+http-timeout.bugfix.md
@@ -1,0 +1,1 @@
+Increase the HTTP client timeout to 60s so cold INFORMATION_SCHEMA lookups (notably the unified drift-catalog UNION ALL) no longer surface as "read operation timed out" on the default 5s budget.

--- a/dbt/adapters/confluent/connections.py
+++ b/dbt/adapters/confluent/connections.py
@@ -329,6 +329,10 @@ class ConfluentConnectionManager(SQLConnectionManager):
                 endpoint=credentials.endpoint,
                 database=credentials.schema,
                 http_user_agent=user_agent,
+                # INFORMATION_SCHEMA queries (especially the unified UNION ALL drift
+                # catalog) routinely take longer than the default 5s timeout on cold
+                # metadata lookups, surfacing as a "read operation timed out".
+                http_timeout_secs=60
             )
             connection.state = "open"
             connection.handle = handle

--- a/dbt/adapters/confluent/connections.py
+++ b/dbt/adapters/confluent/connections.py
@@ -332,7 +332,7 @@ class ConfluentConnectionManager(SQLConnectionManager):
                 # INFORMATION_SCHEMA queries (especially the unified UNION ALL drift
                 # catalog) routinely take longer than the default 5s timeout on cold
                 # metadata lookups, surfacing as a "read operation timed out".
-                http_timeout_secs=60
+                http_timeout_secs=60,
             )
             connection.state = "open"
             connection.handle = handle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "dbt-adapters~=1.16",
   "agate~=1.0",
   "httpx>=0.23.0,<0.29.0",
-  "confluent-sql~=0.3.0",
+  "confluent-sql~=0.3.1",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -211,14 +211,14 @@ wheels = [
 
 [[package]]
 name = "confluent-sql"
-version = "0.3.0"
+version = "0.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/80/f2482406c87fb325546c38cabca9bc32ee26a03bc41b58b3ac8aa0cd6b73/confluent_sql-0.3.0.tar.gz", hash = "sha256:9791ad7b66d43b2d4cbb8a13d4d45c4cb44e645818d051aa7a8d493a216974f7", size = 188089, upload-time = "2026-04-09T14:33:59.469Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/a6/a0a5cbe3ed306c04801bc9b21aabc5fba3149e0400dfcdd666f0b79f33ba/confluent_sql-0.3.1.tar.gz", hash = "sha256:d2c19cfa90b3540fff5476730fd348c72cfc90629cf0ca1d4e8ff5ae2b07fe5b", size = 199471, upload-time = "2026-05-21T14:10:44.581Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/92/df5f3daa8eb7ca73a2ceb70baccf90c97e3fd12e70aa24a6f7fc52ef42b3/confluent_sql-0.3.0-py3-none-any.whl", hash = "sha256:e591a6f1433d2ac6650dc4835b429cf4a69048a31fcde12be6fd00e724eb662c", size = 73519, upload-time = "2026-04-09T14:33:58.363Z" },
+    { url = "https://files.pythonhosted.org/packages/12/b7/a182469c07abea12c29d5e697c6febd7aa9c940d3a1088dcd09064eda8c2/confluent_sql-0.3.1-py3-none-any.whl", hash = "sha256:13b08e238f693c1f6059f53ef06153ae5afb39cd1a36db79d1824021a6627cc2", size = 73950, upload-time = "2026-05-21T14:10:43.382Z" },
 ]
 
 [[package]]
@@ -308,7 +308,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "agate", specifier = "~=1.0" },
-    { name = "confluent-sql", specifier = "~=0.3.0" },
+    { name = "confluent-sql", specifier = "~=0.3.1" },
     { name = "dbt-adapters", specifier = "~=1.16" },
     { name = "dbt-common", specifier = "~=1.12" },
     { name = "dbt-core", specifier = "~=1.11" },
@@ -467,7 +467,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [


### PR DESCRIPTION
This PR pins confluent-sql to 0.3.1 and uses the new option to change the default timeout for http requests, since we routinely encountered network errors due to some queries taking more than the default of 5 seconds sometimes.
Set the default to 60, we can probably lower it a bit, but unless this causes problems I'd err on this side for now