### PR TITLE
Fix delete statement handling on 403

### DIFF
--- a/changes/58.bugfix.md
+++ b/changes/58.bugfix.md
@@ -1,0 +1,1 @@
+Fix `dbt run` failures under compute-pool-scoped FlinkDeveloper roles caused by DELETE-on-missing Flink statements returning 403 (not 404). The adapter now warns rather than errors on a 403 from statement DELETE, and retries CREATE on 409 name-conflicts to handle the async teardown race.

--- a/dbt/adapters/confluent/connections.py
+++ b/dbt/adapters/confluent/connections.py
@@ -8,7 +8,11 @@ from typing import TYPE_CHECKING, Any
 
 import confluent_sql
 from confluent_sql import HIDDEN_LABEL, Cursor
-from confluent_sql.exceptions import ComputePoolExhaustedError, StatementNotFoundError
+from confluent_sql.exceptions import (
+    ComputePoolExhaustedError,
+    OperationalError,
+    StatementNotFoundError,
+)
 from confluent_sql.execution_mode import ExecutionMode
 from dbt_common.events.contextvars import get_node_info
 from dbt_common.events.functions import fire_event
@@ -91,6 +95,96 @@ class ConfluentCredentials(Credentials):
             return (*keys, "cloud_provider", "cloud_region")
 
 
+def _execute_query_with_retry(
+    cursor: "confluent_sql.Cursor",
+    sql: str,
+    bindings: Any | None,
+    retryable_exceptions: tuple[type[Exception], ...],
+    retry_limit: int,
+    attempt: int,
+    statement_name: str | None = None,
+    statement_labels: list[str] | None = None,
+):
+    """Execute the cursor and retry on transient failures.
+
+    A success sees the try exit cleanly and avoid any recursive retries.
+    Failure begins a sleep and retry routine.
+
+    Lives at module scope (not as a closure inside add_query) so it can
+    be unit-tested in isolation.
+    """
+    try:
+        cursor.execute(
+            sql, bindings, statement_name=statement_name, statement_labels=statement_labels
+        )
+    except retryable_exceptions as e:
+        # Cease retries and fail when limit is hit.
+        if attempt >= retry_limit:
+            raise e
+
+        backoff = min(attempt * 3, 15)
+        retries_left = retry_limit - attempt
+
+        if isinstance(e, ComputePoolExhaustedError):
+            fire_event(
+                AdapterEventWarning(
+                    base_msg=f"Compute pool exhausted. {retries_left} retries left. "
+                    f"Retrying in {backoff} seconds."
+                )
+            )
+        else:
+            fire_event(
+                AdapterEventDebug(
+                    base_msg=f"Got a retryable error {type(e)}. {retries_left} retries left. "
+                    f"Retrying in {backoff} seconds.\nError:\n{e}"
+                )
+            )
+        time.sleep(backoff)
+
+        # Reuse the same statement name on retry. ComputePoolExhaustedError
+        # cleans up the failed statement, so the name is available for reuse.
+        return _execute_query_with_retry(
+            cursor=cursor,
+            sql=sql,
+            bindings=bindings,
+            retryable_exceptions=retryable_exceptions,
+            retry_limit=retry_limit,
+            attempt=attempt + 1,
+            statement_labels=statement_labels,
+            statement_name=statement_name,
+        )
+    except OperationalError as e:
+        # "Statement with name X already exists" — happens when a prior
+        # statement with the same name is still tearing down asynchronously
+        # after a DELETE. We retry until the name frees up.
+        if getattr(e, "http_status_code", None) != 409:
+            raise
+        if attempt >= retry_limit:
+            raise
+
+        backoff = min(attempt * 3, 15)
+        retries_left = retry_limit - attempt
+        fire_event(
+            AdapterEventDebug(
+                base_msg=f"Statement name '{statement_name}' is already in use "
+                f"(prior statement may still be tearing down). "
+                f"{retries_left} retries left. Retrying in {backoff} seconds."
+            )
+        )
+        time.sleep(backoff)
+
+        return _execute_query_with_retry(
+            cursor=cursor,
+            sql=sql,
+            bindings=bindings,
+            retryable_exceptions=retryable_exceptions,
+            retry_limit=retry_limit,
+            attempt=attempt + 1,
+            statement_labels=statement_labels,
+            statement_name=statement_name,
+        )
+
+
 class ConfluentConnectionManager(SQLConnectionManager):
     TYPE = "confluent"
 
@@ -157,62 +251,6 @@ class ConfluentConnectionManager(SQLConnectionManager):
         statement_name: if provided, used as the Flink statement name (deterministic).
         If None, a UUID-based name is generated (for metadata/schema queries).
         """
-
-        def _execute_query_with_retry(
-            cursor: confluent_sql.Cursor,
-            sql: str,
-            bindings: Any | None,
-            retryable_exceptions: tuple[type[Exception], ...],
-            retry_limit: int,
-            attempt: int,
-            statement_name: str | None = None,
-            statement_labels: list[str] | None = None,
-        ):
-            """
-            A success sees the try exit cleanly and avoid any recursive
-            retries. Failure begins a sleep and retry routine.
-            """
-            try:
-                cursor.execute(
-                    sql, bindings, statement_name=statement_name, statement_labels=statement_labels
-                )
-            except retryable_exceptions as e:
-                # Cease retries and fail when limit is hit.
-                if attempt >= retry_limit:
-                    raise e
-
-                backoff = min(attempt * 3, 15)
-                retries_left = retry_limit - attempt
-
-                if isinstance(e, ComputePoolExhaustedError):
-                    fire_event(
-                        AdapterEventWarning(
-                            base_msg=f"Compute pool exhausted. {retries_left} retries left. "
-                            f"Retrying in {backoff} seconds."
-                        )
-                    )
-                else:
-                    fire_event(
-                        AdapterEventDebug(
-                            base_msg=f"Got a retryable error {type(e)}. {retries_left} retries left. "
-                            f"Retrying in {backoff} seconds.\nError:\n{e}"
-                        )
-                    )
-                time.sleep(backoff)
-
-                # Reuse the same statement name on retry. ComputePoolExhaustedError
-                # cleans up the failed statement, so the name is available for reuse.
-                return _execute_query_with_retry(
-                    cursor=cursor,
-                    sql=sql,
-                    bindings=bindings,
-                    retryable_exceptions=retryable_exceptions,
-                    retry_limit=retry_limit,
-                    attempt=attempt + 1,
-                    statement_labels=statement_labels,
-                    statement_name=statement_name,
-                )
-
         connection = self.get_thread_connection()
         if auto_begin and connection.transaction_open is False:
             self.begin()

--- a/dbt/adapters/confluent/impl.py
+++ b/dbt/adapters/confluent/impl.py
@@ -1,12 +1,12 @@
 import logging
 import re
-import time
 from dataclasses import dataclass, field
 
 import agate
-from confluent_sql.exceptions import StatementNotFoundError
+from confluent_sql.exceptions import OperationalError, StatementNotFoundError
 from dbt_common.contracts.constraints import ConstraintType, ModelLevelConstraint
 from dbt_common.events.contextvars import get_node_info
+from dbt_common.events.functions import fire_event
 from dbt_common.exceptions import CompilationError, DbtDatabaseError
 
 from dbt.adapters.base import BaseRelation, available
@@ -14,6 +14,7 @@ from dbt.adapters.base.impl import InformationSchema, _parse_callback_empty_tabl
 from dbt.adapters.confluent import ConfluentColumn, ConfluentConnectionManager
 from dbt.adapters.contracts.connection import AdapterResponse
 from dbt.adapters.contracts.relation import Policy
+from dbt.adapters.events.types import AdapterEventWarning
 from dbt.adapters.sql import SQLAdapter
 
 from .naming import sanitize_statement_name
@@ -156,44 +157,55 @@ class ConfluentAdapter(SQLAdapter):
         return sanitize_statement_name(name)
 
     @available
-    def delete_statement(self, statement_name: str) -> None:
-        """Delete a Flink statement by name and wait for deletion to complete.
+    def delete_statement(self, statement_name: str, expect_exists: bool = True) -> None:
+        """Delete a Flink statement by name. No-op if it doesn't exist.
 
-        Deletion of RUNNING statements is async (the job must stop first),
-        so we poll until the statement is gone (404).
-        No-op if the statement doesn't already exist.
+        Compute-pool-scoped FlinkDeveloper roles return 403 — not 404 — when
+        the target statement does not exist (Confluent Cloud intentionally
+        hides existence across pool boundaries). We can't disambiguate
+        "missing" from "no permission" from the response, so we swallow
+        403 and surface a warning instead of failing. Real permission
+        problems will still surface on subsequent operations that need
+        the same scope.
+
+        expect_exists: if True (default), a 403 is surprising — the caller
+            had reason to believe the statement existed — so we emit a loud
+            AdapterEventWarning. If False (e.g. orphan-cleanup paths where
+            the statement is opportunistically deleted), 403 is the expected
+            response and we log quietly at debug level.
+
+        Async deletion is not awaited here: the connection manager retries
+        CREATE on 409 to handle the in-flight teardown race against the
+        next statement that reuses this name.
         """
         conn = self.connections.get_thread_connection()
         handle = conn.handle
-
-        # Send the delete request (no-op on 404).
-        handle.delete_statement(statement_name)
-
-        # Check if the statement is already gone after the delete request.
         try:
-            handle.get_statement(statement_name)
+            handle.delete_statement(statement_name)
         except StatementNotFoundError:
             return  # Already gone (either deleted instantly or never existed)
-
-        # Statement still exists — it's being stopped. Poll until gone.
-        logger.info("Waiting for statement '%s' to be deleted...", statement_name)
-        max_wait = 60
-        waited = 0
-        attempt = 1
-        while waited < max_wait:
-            backoff = min(2**attempt, 15)
-            time.sleep(backoff)
-            waited += backoff
-            attempt += 1
-            try:
-                handle.get_statement(statement_name)
-            except StatementNotFoundError:
-                return  # Successfully deleted
-
-        raise DbtDatabaseError(
-            f"Statement '{statement_name}' still exists after {waited}s. "
-            f"Flink may still be stopping the job."
-        )
+        except OperationalError as e:
+            if getattr(e, "http_status_code", None) != 403:
+                raise
+            if expect_exists:
+                fire_event(
+                    AdapterEventWarning(
+                        base_msg=(
+                            f"Got 403 when deleting Flink statement "
+                            f"'{statement_name}'. This is the expected response "
+                            f"for a missing statement under compute-pool-scoped "
+                            f"roles, so we are ignoring it. If subsequent "
+                            f"operations fail unexpectedly, verify that the API "
+                            f"key has permission to manage statements in this "
+                            f"compute pool."
+                        )
+                    )
+                )
+            else:
+                logger.debug(
+                    "Got 403 on opportunistic delete of statement '%s' (no orphan present).",
+                    statement_name,
+                )
 
     @classmethod
     def convert_text_type(cls, agate_table: agate.Table, col_idx: int) -> str:
@@ -397,6 +409,23 @@ class ConfluentAdapter(SQLAdapter):
         # canonical form.
         existing_map = {col["column_name"]: col["data_type"] for col in existing_columns}
         expected_map = {col["column_name"]: col["data_type"] for col in expected_columns}
+
+        # An empty expected_map means the drift-check temp table came back with
+        # zero columns from INFORMATION_SCHEMA. The temp table was just created
+        # from the model's column definitions / select query, so it has columns;
+        # an empty result almost always means Confluent Cloud's INFORMATION_SCHEMA
+        # hasn't yet propagated the freshly-created table. Surface this as a
+        # retriable database error rather than letting it cascade into a false
+        # "drift detected" message.
+        if not expected_map:
+            raise DbtDatabaseError(
+                f"Drift check could not introspect the expected schema for "
+                f"'{relation_name}': the temp table created from the model "
+                f"definition returned no columns from INFORMATION_SCHEMA. "
+                f"This usually indicates a transient Confluent Cloud metadata "
+                f"propagation lag. Retry with `dbt retry`; if it persists, "
+                f"run with `--full-refresh` or file a bug."
+            )
 
         existing_names = sorted(existing_map)
         expected_names = sorted(expected_map)

--- a/dbt/include/confluent/macros/materializations/models/helpers.sql
+++ b/dbt/include/confluent/macros/materializations/models/helpers.sql
@@ -1,8 +1,11 @@
-{% macro delete_statement_if_exists(statement_name) %}
+{% macro delete_statement_if_exists(statement_name, expect_exists=true) %}
   {# Delete an existing Flink statement by name so we can re-create it.
-     No-op if the statement doesn't exist (confluent-sql handles 404). #}
+     No-op if the statement doesn't exist (confluent-sql handles 404).
+     expect_exists: see adapter.delete_statement — controls whether a 403
+     (treated as "missing statement" under pool-scoped roles) emits a loud
+     warning or just a debug log. #}
   {% if execute %}
-    {% do adapter.delete_statement(statement_name) %}
+    {% do adapter.delete_statement(statement_name, expect_exists=expect_exists) %}
   {% endif %}
 {% endmacro %}
 
@@ -35,9 +38,11 @@
   {% else %}
     {# No relation exists, but orphaned Flink statements may linger if the table
        was dropped without deleting its statements (e.g. external cleanup).
-       Delete them so the materialization can create fresh ones. #}
-    {{ delete_statement_if_exists(get_statement_name()) }}
-    {{ delete_statement_if_exists(get_statement_name('-ddl')) }}
+       Delete them so the materialization can create fresh ones. We don't expect
+       them to exist in the common case (first-time run), so suppress the loud
+       warning the adapter would otherwise emit for a pool-scoped 403. #}
+    {{ delete_statement_if_exists(get_statement_name(), expect_exists=false) }}
+    {{ delete_statement_if_exists(get_statement_name('-ddl'), expect_exists=false) }}
   {% endif %}
   {{ return(false) }}
 {% endmacro %}

--- a/dbt/include/confluent/macros/materializations/models/view.sql
+++ b/dbt/include/confluent/macros/materializations/models/view.sql
@@ -4,8 +4,10 @@
 
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
-  -- delete existing statement and drop the relation if it exists already
-  {{ delete_statement_if_exists(get_statement_name()) }}
+  -- delete existing statement and drop the relation if it exists already.
+  -- If there's no existing relation, the statement probably doesn't exist either,
+  -- so suppress the loud warning the adapter emits for a pool-scoped 403.
+  {{ delete_statement_if_exists(get_statement_name(), expect_exists=(existing_relation is not none)) }}
   {{ drop_relation_if_exists(existing_relation) }}
 
   -- `BEGIN` happens here:

--- a/tests/functional/adapter/test_schema_drift.py
+++ b/tests/functional/adapter/test_schema_drift.py
@@ -25,15 +25,41 @@ def get_result_by_name(results, name):
     return None
 
 
-def assert_drift_error(results, name):
-    """Assert that a specific result failed with a drift detection error."""
+_DRIFT_KIND_SUBSTRINGS = {
+    # Column added / removed / renamed → mismatch between existing and expected
+    # column name lists. Match on the labels in the rendered error.
+    "columns": "Existing columns:",
+    # Column data type changed.
+    "type": "type mismatch",
+    # WITH-options drift.
+    "options": "Table options drift detected",
+}
+
+
+def assert_drift_error(results, name, kind):
+    """Assert that `name` errored with a drift detection error of the given kind.
+
+    kind: one of 'columns', 'type', 'options'. Forces tests to be specific about
+    which drift they expect; a generic "any drift error" match would have hidden
+    misdiagnosed failures (e.g. an empty expected_columns producing a fake
+    column-list drift message).
+    """
+    try:
+        expected_substring = _DRIFT_KIND_SUBSTRINGS[kind]
+    except KeyError as e:
+        raise ValueError(
+            f"Unknown drift kind {kind!r}; expected one of {sorted(_DRIFT_KIND_SUBSTRINGS)}"
+        ) from e
+
     result = get_result_by_name(results, name)
     assert result is not None, f"{name} not found in results"
     assert result.status.name == "Error", (
         f"{name} expected status 'Error' but got '{result.status.name}'"
     )
-    assert "drift detected" in result.message.lower(), (
-        f"{name} error was not a drift error: {result.message}"
+    assert expected_substring in result.message, (
+        f"{name} error did not match drift kind {kind!r} "
+        f"(expected substring {expected_substring!r}).\n"
+        f"Actual message: {result.message}"
     )
 
 
@@ -269,17 +295,17 @@ class TestTableSchemaDrift(ConfluentFixtures):
     def test_extra_column_detected(self, project):
         set_model_file(project, relation(project, "my_table"), TABLE_MODEL_EXTRA_COLUMN)
         result = run_dbt(["run"], expect_pass=False)
-        assert_drift_error(result, "my_table")
+        assert_drift_error(result, "my_table", kind="columns")
 
     def test_removed_column_detected(self, project):
         set_model_file(project, relation(project, "my_table"), TABLE_MODEL_REMOVED_COLUMN)
         result = run_dbt(["run"], expect_pass=False)
-        assert_drift_error(result, "my_table")
+        assert_drift_error(result, "my_table", kind="columns")
 
     def test_renamed_column_detected(self, project):
         set_model_file(project, relation(project, "my_table"), TABLE_MODEL_RENAMED_COLUMN)
         result = run_dbt(["run"], expect_pass=False)
-        assert_drift_error(result, "my_table")
+        assert_drift_error(result, "my_table", kind="columns")
 
     def test_reordered_columns_not_detected(self, project):
         """Column reordering is not considered drift — order doesn't matter for Kafka tables."""
@@ -293,7 +319,7 @@ class TestTableSchemaDrift(ConfluentFixtures):
         """Changing column data types should raise an error without --full-refresh."""
         set_model_file(project, relation(project, "my_table"), TABLE_MODEL_TYPE_CHANGE)
         result = run_dbt(["run"], expect_pass=False)
-        assert_drift_error(result, "my_table")
+        assert_drift_error(result, "my_table", kind="type")
 
 
 class TestTableFullRefreshFixesDrift(ConfluentFixtures):
@@ -381,14 +407,14 @@ class TestStreamingTableSchemaDrift(ConfluentFixtures):
             STREAMING_TABLE_MODEL_DIFFERENT_OPTIONS,
         )
         result = run_dbt(["run"], expect_pass=False)
-        assert_drift_error(result, "my_streaming_table")
+        assert_drift_error(result, "my_streaming_table", kind="options")
 
     def test_column_drift_detected(self, project):
         set_model_file(
             project, relation(project, "my_streaming_table"), STREAMING_TABLE_MODEL_EXTRA_COLUMN
         )
         result = run_dbt(["run"], expect_pass=False)
-        assert_drift_error(result, "my_streaming_table")
+        assert_drift_error(result, "my_streaming_table", kind="columns")
 
     def test_type_change_detected(self, project):
         """Changing column data types should raise an error without --full-refresh."""
@@ -396,7 +422,7 @@ class TestStreamingTableSchemaDrift(ConfluentFixtures):
             project, relation(project, "my_streaming_table"), STREAMING_TABLE_MODEL_TYPE_CHANGE
         )
         result = run_dbt(["run"], expect_pass=False)
-        assert_drift_error(result, "my_streaming_table")
+        assert_drift_error(result, "my_streaming_table", kind="type")
 
 
 # ---------------------------------------------------------------------------
@@ -443,7 +469,7 @@ class TestStreamingSourceSchemaDrift(ConfluentFixtures):
             project, relation(project, "my_source"), STREAMING_SOURCE_MODEL_DIFFERENT_OPTIONS
         )
         result = run_dbt(["run"], expect_pass=False)
-        assert_drift_error(result, "my_source")
+        assert_drift_error(result, "my_source", kind="options")
 
     def test_extra_column_detected(self, project):
         """Adding a column should raise an error without --full-refresh."""
@@ -451,7 +477,7 @@ class TestStreamingSourceSchemaDrift(ConfluentFixtures):
             project, relation(project, "my_source"), STREAMING_SOURCE_MODEL_EXTRA_COLUMN
         )
         result = run_dbt(["run"], expect_pass=False)
-        assert_drift_error(result, "my_source")
+        assert_drift_error(result, "my_source", kind="columns")
 
     def test_removed_column_detected(self, project):
         """Removing a column should raise an error without --full-refresh."""
@@ -459,7 +485,7 @@ class TestStreamingSourceSchemaDrift(ConfluentFixtures):
             project, relation(project, "my_source"), STREAMING_SOURCE_MODEL_REMOVED_COLUMN
         )
         result = run_dbt(["run"], expect_pass=False)
-        assert_drift_error(result, "my_source")
+        assert_drift_error(result, "my_source", kind="columns")
 
     def test_renamed_column_detected(self, project):
         """Renaming a column should raise an error without --full-refresh."""
@@ -467,13 +493,13 @@ class TestStreamingSourceSchemaDrift(ConfluentFixtures):
             project, relation(project, "my_source"), STREAMING_SOURCE_MODEL_RENAMED_COLUMN
         )
         result = run_dbt(["run"], expect_pass=False)
-        assert_drift_error(result, "my_source")
+        assert_drift_error(result, "my_source", kind="columns")
 
     def test_type_change_detected(self, project):
         """Changing column data types should raise an error without --full-refresh."""
         set_model_file(project, relation(project, "my_source"), STREAMING_SOURCE_MODEL_TYPE_CHANGE)
         result = run_dbt(["run"], expect_pass=False)
-        assert_drift_error(result, "my_source")
+        assert_drift_error(result, "my_source", kind="type")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_add_query_retry.py
+++ b/tests/unit/test_add_query_retry.py
@@ -1,0 +1,107 @@
+"""Unit tests for _execute_query_with_retry.
+
+Covers:
+- Success on first attempt (no retry).
+- Retry on existing retryable_exceptions class (ComputePoolExhaustedError).
+- Retry on OperationalError with http_status_code=409 (name-conflict
+  during async teardown of a prior statement with the same name).
+- Pass-through on OperationalError with a non-409 status code.
+- Exhaustion: re-raises after retry_limit attempts.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from confluent_sql.exceptions import ComputePoolExhaustedError, OperationalError
+
+from dbt.adapters.confluent.connections import _execute_query_with_retry
+
+
+@pytest.fixture(autouse=True)
+def no_sleep():
+    """Replace time.sleep so the retry tests run instantly."""
+    with patch("dbt.adapters.confluent.connections.time.sleep"):
+        yield
+
+
+def _run(cursor, **overrides):
+    kwargs = {
+        "cursor": cursor,
+        "sql": "SELECT 1",
+        "bindings": None,
+        "retryable_exceptions": (ComputePoolExhaustedError,),
+        "retry_limit": 5,
+        "attempt": 1,
+        "statement_name": "dbt-test-stmt",
+        "statement_labels": ["dbt-confluent"],
+    }
+    kwargs.update(overrides)
+    return _execute_query_with_retry(**kwargs)
+
+
+class TestRetryBehavior:
+    def test_success_no_retry(self):
+        cursor = MagicMock()
+        _run(cursor)
+        assert cursor.execute.call_count == 1
+
+    def test_retries_on_compute_pool_exhausted_then_succeeds(self):
+        cursor = MagicMock()
+        cursor.execute.side_effect = [
+            ComputePoolExhaustedError("pool exhausted", "dbt-test-stmt", True),
+            None,
+        ]
+        _run(cursor)
+        assert cursor.execute.call_count == 2
+
+    def test_retries_on_409_then_succeeds(self):
+        cursor = MagicMock()
+        cursor.execute.side_effect = [
+            OperationalError("name in use", http_status_code=409),
+            None,
+        ]
+        _run(cursor)
+        assert cursor.execute.call_count == 2
+
+    def test_does_not_retry_on_non_409_operational_error(self):
+        cursor = MagicMock()
+        e = OperationalError("permission denied", http_status_code=403)
+        cursor.execute.side_effect = e
+        with pytest.raises(OperationalError) as exc_info:
+            _run(cursor)
+        assert exc_info.value is e
+        assert cursor.execute.call_count == 1
+
+    def test_does_not_retry_on_operational_error_without_status(self):
+        cursor = MagicMock()
+        cursor.execute.side_effect = OperationalError("no status code")
+        with pytest.raises(OperationalError):
+            _run(cursor)
+        assert cursor.execute.call_count == 1
+
+    def test_exhausts_retries_and_raises_on_persistent_409(self):
+        cursor = MagicMock()
+        cursor.execute.side_effect = OperationalError("still in use", http_status_code=409)
+        with pytest.raises(OperationalError):
+            _run(cursor, retry_limit=3)
+        # attempt=1 plus 2 retries = 3 calls; attempt #3 hits the limit and re-raises.
+        assert cursor.execute.call_count == 3
+
+    def test_exhausts_retries_and_raises_on_persistent_pool_exhausted(self):
+        cursor = MagicMock()
+        cursor.execute.side_effect = ComputePoolExhaustedError("pool", "dbt-test-stmt", True)
+        with pytest.raises(ComputePoolExhaustedError):
+            _run(cursor, retry_limit=2)
+        assert cursor.execute.call_count == 2
+
+    def test_reuses_statement_name_across_retries(self):
+        """The same statement_name must be passed to each cursor.execute attempt."""
+        cursor = MagicMock()
+        cursor.execute.side_effect = [
+            OperationalError("name in use", http_status_code=409),
+            OperationalError("name in use", http_status_code=409),
+            None,
+        ]
+        _run(cursor, statement_name="dbt-fixed-name")
+        for call in cursor.execute.call_args_list:
+            assert call.kwargs["statement_name"] == "dbt-fixed-name"

--- a/tests/unit/test_check_schema_drift.py
+++ b/tests/unit/test_check_schema_drift.py
@@ -2,7 +2,7 @@
 
 import agate
 import pytest
-from dbt_common.exceptions import CompilationError
+from dbt_common.exceptions import CompilationError, DbtDatabaseError
 
 from dbt.adapters.confluent.impl import ConfluentAdapter
 
@@ -135,3 +135,20 @@ class TestCheckSchemaDrift:
             expected_with={"rows-per-second": 1},
             existing_options={"rows-per-second": "1"},
         )
+
+    def test_empty_expected_columns_raises_distinct_error(self, adapter):
+        """An empty expected_columns must NOT masquerade as a column-list drift.
+
+        The drift-check temp table coming back with no columns from
+        INFORMATION_SCHEMA is almost always a transient Confluent Cloud
+        metadata propagation lag, so we surface it as a retriable
+        DbtDatabaseError with a distinct, diagnosable message.
+        """
+        existing = _make_agate_table([("id", "BIGINT"), ("value", "STRING")])
+        expected = _make_agate_table([])
+        with pytest.raises(DbtDatabaseError) as excinfo:
+            adapter.check_schema_drift("t", existing, expected, {}, {})
+        msg = str(excinfo.value)
+        assert "INFORMATION_SCHEMA" in msg
+        # Must not look like a regular column-list drift error.
+        assert "drift detected" not in msg.lower()

--- a/tests/unit/test_delete_statement.py
+++ b/tests/unit/test_delete_statement.py
@@ -1,0 +1,95 @@
+"""Unit tests for ConfluentAdapter.delete_statement.
+
+The adapter calls confluent-sql's delete unconditionally and catches the
+403 that compute-pool-scoped FlinkDeveloper roles return for a missing
+statement (Confluent Cloud hides existence across pool boundaries — see
+GH #58). The caller indicates whether 403 should be loud (expect_exists=True,
+default) or quiet (expect_exists=False, used for orphan-cleanup paths).
+"""
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from confluent_sql.exceptions import OperationalError
+
+from dbt.adapters.confluent.impl import ConfluentAdapter
+
+
+class TestDeleteStatement:
+    @pytest.fixture
+    def adapter(self):
+        return ConfluentAdapter.__new__(ConfluentAdapter)
+
+    @pytest.fixture
+    def handle(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def conn(self, handle):
+        return SimpleNamespace(handle=handle)
+
+    @pytest.fixture
+    def wire_connection(self, adapter, conn):
+        adapter.connections = MagicMock()
+        adapter.connections.get_thread_connection.return_value = conn
+        return adapter
+
+    def test_successful_delete_calls_handle(self, wire_connection, handle):
+        wire_connection.delete_statement("dbt-some-stmt")
+        handle.delete_statement.assert_called_once_with("dbt-some-stmt")
+
+    def test_403_with_expect_exists_emits_warning(self, wire_connection, handle):
+        handle.delete_statement.side_effect = OperationalError(
+            "error sending request '403'", http_status_code=403
+        )
+        with patch("dbt.adapters.confluent.impl.fire_event") as fire_event:
+            wire_connection.delete_statement("dbt-some-stmt", expect_exists=True)
+
+        fire_event.assert_called_once()
+        event = fire_event.call_args.args[0]
+        assert "403" in event.base_msg
+        assert "dbt-some-stmt" in event.base_msg
+
+    def test_403_with_expect_exists_default_emits_warning(self, wire_connection, handle):
+        """Default is expect_exists=True, so a 403 still warns."""
+        handle.delete_statement.side_effect = OperationalError(
+            "error sending request '403'", http_status_code=403
+        )
+        with patch("dbt.adapters.confluent.impl.fire_event") as fire_event:
+            wire_connection.delete_statement("dbt-some-stmt")
+
+        fire_event.assert_called_once()
+
+    def test_403_without_expect_exists_logs_debug_no_warning(
+        self, wire_connection, handle, caplog
+    ):
+        handle.delete_statement.side_effect = OperationalError(
+            "error sending request '403'", http_status_code=403
+        )
+        with (
+            patch("dbt.adapters.confluent.impl.fire_event") as fire_event,
+            caplog.at_level(logging.DEBUG, logger="dbt.adapters.confluent.impl"),
+        ):
+            wire_connection.delete_statement("dbt-some-stmt", expect_exists=False)
+
+        fire_event.assert_not_called()
+        assert any(
+            "dbt-some-stmt" in rec.message and "opportunistic" in rec.message
+            for rec in caplog.records
+        )
+
+    def test_non_403_operational_error_reraises(self, wire_connection, handle):
+        err = OperationalError("internal server error", http_status_code=500)
+        handle.delete_statement.side_effect = err
+        with pytest.raises(OperationalError) as exc_info:
+            wire_connection.delete_statement("dbt-some-stmt")
+        assert exc_info.value is err
+
+    def test_operational_error_without_status_reraises(self, wire_connection, handle):
+        """An OperationalError with no http_status_code (e.g. raised by older
+        confluent-sql code paths) is not a 403 and must propagate."""
+        handle.delete_statement.side_effect = OperationalError("some bare error")
+        with pytest.raises(OperationalError):
+            wire_connection.delete_statement("dbt-some-stmt")


### PR DESCRIPTION
Fixes #58 

The main fix is that a `403` returned from a `delete_statement` doesn't raise an exception anymore. It does mean that genuine 403s might be "ignored", but we would expect auth issues to come up in other places in that case.
A 403 raises a loud warning if it wasn't "expected". This means that if we get a 403 during an orphan cleanup query, we quitely ignore it, but if we get it in any other query, the adapter issues a warning.

To make this work, instead of waiting for a statement to be deleted in `delete_statement` by checking what we get from `get_statement`, the delete call does not check anymore, and we now have a retry loop in the creation phase.
This change made the test suite go from over 50 minutes to 30 minutes for the full run, so delete statement polling was taking a lot of time.

The fix has been tested on a live cluster where I could reproduce the issue with the published version.

Note: moved `_execute_retry_with_query` out of the class to make tests easier, the main difference is the handling of the specific error.