### PR TITLE
Release 0.2.1

### DIFF
--- a/.semaphore/publish_to_pypi.yml
+++ b/.semaphore/publish_to_pypi.yml
@@ -21,7 +21,3 @@ blocks:
             - DBT_CONFLUENT_KEY=$(vault kv get -field=dbt-confluent v1/ci/kv/pypi/pypi.org)
             - uv build
             - uv publish -u __token__ -p "$DBT_CONFLUENT_KEY" dist/*
-            - VERSION=$(grep -E '^version' dbt/adapters/confluent/__version__.py | sed -E 's/.*"([^"]+)".*/\1/')
-            - TAG="v$VERSION"
-            - git tag -a "$TAG" -m "Release $VERSION"
-            - git push origin "$TAG"

--- a/.semaphore/publish_to_pypi.yml
+++ b/.semaphore/publish_to_pypi.yml
@@ -21,3 +21,7 @@ blocks:
             - DBT_CONFLUENT_KEY=$(vault kv get -field=dbt-confluent v1/ci/kv/pypi/pypi.org)
             - uv build
             - uv publish -u __token__ -p "$DBT_CONFLUENT_KEY" dist/*
+            - VERSION=$(grep -E '^version' dbt/adapters/confluent/__version__.py | sed -E 's/.*"([^"]+)".*/\1/')
+            - TAG="v$VERSION"
+            - git tag -a "$TAG" -m "Release $VERSION"
+            - git push origin "$TAG"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+dbt-confluent 0.2.1 (2026-05-27)
+
+# Bugfixes
+
+- Fix `dbt run` failures under compute-pool-scoped FlinkDeveloper roles caused by DELETE-on-missing Flink statements returning 403 (not 404). The adapter now warns rather than errors on a 403 from statement DELETE, and retries CREATE on 409 name-conflicts to handle the async teardown race. ([#58](https://github.com/confluentinc/dbt-confluent/issues/58))
+- Increase the HTTP client timeout to 60s so cold INFORMATION_SCHEMA lookups (notably the unified drift-catalog UNION ALL) no longer surface as "read operation timed out" on the default 5s budget.
+
+
 dbt-confluent 0.2.0 (2026-04-22)
 
 # Features

--- a/changes/+http-timeout.bugfix.md
+++ b/changes/+http-timeout.bugfix.md
@@ -1,1 +1,0 @@
-Increase the HTTP client timeout to 60s so cold INFORMATION_SCHEMA lookups (notably the unified drift-catalog UNION ALL) no longer surface as "read operation timed out" on the default 5s budget.

--- a/changes/58.bugfix.md
+++ b/changes/58.bugfix.md
@@ -1,1 +1,0 @@
-Fix `dbt run` failures under compute-pool-scoped FlinkDeveloper roles caused by DELETE-on-missing Flink statements returning 403 (not 404). The adapter now warns rather than errors on a 403 from statement DELETE, and retries CREATE on 409 name-conflicts to handle the async teardown race.

--- a/dbt/adapters/confluent/__version__.py
+++ b/dbt/adapters/confluent/__version__.py
@@ -1,1 +1,1 @@
-version = "0.2.0"
+version = "0.2.1"


### PR DESCRIPTION
Compact changelog for release 0.2.1, adds a step to push a tag from CI after publication is succesful