### PR TITLE
Upgraded to confluent-sql 0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ dbt init my_project
 
 Select `confluent` as the adapter and fill in the prompts for your Confluent Cloud credentials (API key, compute pool, environment, etc.).
 
+You can authenticate with either a **Global** Confluent Cloud API key (`global_api_key` / `global_api_secret`, which works against every route) or a **Flink-region** key (`flink_api_key` / `flink_api_secret`). The `compute_pool_id` is optional: omit it to run statements in the environment+region [default compute pool](https://docs.confluent.io/cloud/current/flink/concepts/compute-pools.html#default-compute-pools).
+
 ### Concept mapping
 
 Confluent Cloud Flink uses different terminology than traditional databases. Here's how dbt concepts map to Flink and Confluent Cloud:

--- a/changes/+confluent-sql-0.4.0.feature.md
+++ b/changes/+confluent-sql-0.4.0.feature.md
@@ -1,0 +1,6 @@
+Upgraded the `confluent-sql` driver to `0.4.0`, unlocking two new credential options:
+
+- **Global API keys**: authenticate with `global_api_key` / `global_api_secret` (a "Global" Confluent Cloud key that works against every route) as an alternative to the Flink-region `flink_api_key` / `flink_api_secret` pair. Supply exactly one complete pair; the Global pair is preferred when both are given.
+- **Poolless Flink**: `compute_pool_id` is now optional. When omitted, statements run in the environment+region default compute pool (provisioned if necessary), instead of requiring an explicit pool.
+
+`dbt init` prompts for both choices, and `dbt debug` now reports the configured compute pool.

--- a/dbt/adapters/confluent/connections.py
+++ b/dbt/adapters/confluent/connections.py
@@ -55,10 +55,19 @@ class ConfluentCredentials(Credentials):
     """
 
     # Add credentials members here, like:
-    compute_pool_id: str
     organization_id: str
-    flink_api_key: str
-    flink_api_secret: str
+    # API credentials: supply either a Global key pair (works against every
+    # Confluent Cloud route) or a Flink-region key pair. confluent_sql.connect()
+    # validates that at least one complete pair is present, rejects half-supplied
+    # pairs, and prefers the Global pair when both are given — so we pass these
+    # straight through without re-validating here.
+    global_api_key: str | None = None
+    global_api_secret: str | None = None
+    flink_api_key: str | None = None
+    flink_api_secret: str | None = None
+    # Optional ("poolless"): when omitted, Confluent Cloud Flink runs statements
+    # in the environment+region default compute pool (provisioning if necessary).
+    compute_pool_id: str | None = None
     cloud_provider: str | None = None
     cloud_region: str | None = None
     endpoint: str | None = None
@@ -88,7 +97,7 @@ class ConfluentCredentials(Credentials):
         """
         List of keys to display in the `dbt debug` output.
         """
-        keys = ("organization_id", "database", "schema")
+        keys = ("organization_id", "database", "schema", "compute_pool_id")
         if self.endpoint:
             return (*keys, "endpoint")
         else:
@@ -357,6 +366,8 @@ class ConfluentConnectionManager(SQLConnectionManager):
             user_agent = f"Confluent-dbt/v{version}"
 
             handle = confluent_sql.connect(
+                global_api_key=credentials.global_api_key,
+                global_api_secret=credentials.global_api_secret,
                 flink_api_key=credentials.flink_api_key,
                 flink_api_secret=credentials.flink_api_secret,
                 environment_id=credentials.database,

--- a/dbt/include/confluent/profile_template.yml
+++ b/dbt/include/confluent/profile_template.yml
@@ -14,17 +14,31 @@ prompts:
         hint: "eg: https://flink.us-east-2.aws.private.confluent.cloud"
   organization_id:
     hint: "eg: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-  compute_pool_id:
-    hint: "eg: lfcp-xxxxx"
+  _choose_compute_pool:
+    "Use a specific compute pool":
+      compute_pool_id:
+        hint: "eg: lfcp-xxxxx"
+    # 'Poolless': omitting compute_pool_id lets Confluent Cloud Flink run
+    # statements in the default compute pool (provisioning one if necessary).
+    # Empty mapping = no further prompts; compute_pool_id is left unset.
+    "Use the environment+region default compute pool": {}
   environment_id:
     hint: "eg: env-xxxxxx"
   dbname:
     hint: "Database name"
-  flink_api_key:
-    hint: "Flink API key"
-  flink_api_secret:
-    hint: "Flink API secret"
-    hide_input: true
+  _choose_api_credentials:
+    "Use a Global API key (works against every Confluent Cloud route)":
+      global_api_key:
+        hint: "Global API key"
+      global_api_secret:
+        hint: "Global API secret"
+        hide_input: true
+    "Use a Flink-region API key":
+      flink_api_key:
+        hint: "Flink API key"
+      flink_api_secret:
+        hint: "Flink API secret"
+        hide_input: true
   execution_mode:
     hint: "One of: 'snapshot', 'snapshot_ddl', 'streaming_query', 'streaming_ddl'"
     type: "string"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "dbt-adapters~=1.16",
   "agate~=1.0",
   "httpx>=0.23.0,<0.29.0",
-  "confluent-sql~=0.3.1",
+  "confluent-sql~=0.4.0",
 ]
 
 [dependency-groups]

--- a/tests/unit/test_profile_template.py
+++ b/tests/unit/test_profile_template.py
@@ -39,9 +39,11 @@ class TestProfileTemplate:
             "aws",  # cloud_provider
             "us-west-1",  # cloud_region
             "org-123",  # organization_id
+            1,  # _choose_compute_pool: "Use a specific compute pool"
             "lfcp-abc",  # compute_pool_id
             "env-xyz",  # environment_id
             "my_db",  # dbname
+            2,  # _choose_api_credentials: "Use a Flink-region API key"
             "my-key",  # flink_api_key
             "my-secret",  # flink_api_secret
             "streaming_query",  # execution_mode
@@ -64,9 +66,11 @@ class TestProfileTemplate:
             2,  # _choose_backend_url: "Use a custom endpoint"
             endpoint_url,  # endpoint
             "org-123",  # organization_id
+            1,  # _choose_compute_pool: "Use a specific compute pool"
             "lfcp-abc",  # compute_pool_id
             "env-xyz",  # environment_id
             "my_db",  # dbname
+            2,  # _choose_api_credentials: "Use a Flink-region API key"
             "my-key",  # flink_api_key
             "my-secret",  # flink_api_secret
             "streaming_query",  # execution_mode
@@ -80,6 +84,58 @@ class TestProfileTemplate:
         assert target["endpoint"] == endpoint_url
         assert "cloud_provider" not in target
         assert "cloud_region" not in target
+
+    def test_choose_poolless(self):
+        """Choosing the default compute pool omits compute_pool_id entirely."""
+        template = load_profile_template()
+        prompt_responses = [
+            1,  # _choose_backend_url: "Use cloud_provider and cloud_region"
+            "aws",  # cloud_provider
+            "us-west-1",  # cloud_region
+            "org-123",  # organization_id
+            2,  # _choose_compute_pool: "Use the environment+region default compute pool"
+            "env-xyz",  # environment_id
+            "my_db",  # dbname
+            2,  # _choose_api_credentials: "Use a Flink-region API key"
+            "my-key",  # flink_api_key
+            "my-secret",  # flink_api_secret
+            "streaming_query",  # execution_mode
+            "dbt-confluent-",  # statement_name_prefix
+            "dbt-confluent",  # statement_label
+            1,  # threads
+        ]
+
+        target = _run_generate_target(template["prompts"], prompt_responses)
+
+        assert "compute_pool_id" not in target
+
+    def test_choose_global_api_key(self):
+        """Choosing the Global key prompts for the global pair, not the Flink pair."""
+        template = load_profile_template()
+        prompt_responses = [
+            1,  # _choose_backend_url: "Use cloud_provider and cloud_region"
+            "aws",  # cloud_provider
+            "us-west-1",  # cloud_region
+            "org-123",  # organization_id
+            1,  # _choose_compute_pool: "Use a specific compute pool"
+            "lfcp-abc",  # compute_pool_id
+            "env-xyz",  # environment_id
+            "my_db",  # dbname
+            1,  # _choose_api_credentials: "Use a Global API key"
+            "global-key",  # global_api_key
+            "global-secret",  # global_api_secret
+            "streaming_query",  # execution_mode
+            "dbt-confluent-",  # statement_name_prefix
+            "dbt-confluent",  # statement_label
+            1,  # threads
+        ]
+
+        target = _run_generate_target(template["prompts"], prompt_responses)
+
+        assert target["global_api_key"] == "global-key"
+        assert target["global_api_secret"] == "global-secret"
+        assert "flink_api_key" not in target
+        assert "flink_api_secret" not in target
 
     def test_choose_prompt_message_contains_option_labels(self):
         """Verify the _choose_ prompt displays the human-readable option labels."""

--- a/uv.lock
+++ b/uv.lock
@@ -211,14 +211,14 @@ wheels = [
 
 [[package]]
 name = "confluent-sql"
-version = "0.3.1"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d0/a6/a0a5cbe3ed306c04801bc9b21aabc5fba3149e0400dfcdd666f0b79f33ba/confluent_sql-0.3.1.tar.gz", hash = "sha256:d2c19cfa90b3540fff5476730fd348c72cfc90629cf0ca1d4e8ff5ae2b07fe5b", size = 199471, upload-time = "2026-05-21T14:10:44.581Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/31/01fefe7f1f54f0c0ce353170f1f9779593b5b6cd1f90c370db981e1edc1d/confluent_sql-0.4.0.tar.gz", hash = "sha256:b7cb767d7c7dcea0313cdf213fe129b73caa50e1322012d308e18a9cbc4759f5", size = 217515, upload-time = "2026-06-15T14:19:57.586Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/b7/a182469c07abea12c29d5e697c6febd7aa9c940d3a1088dcd09064eda8c2/confluent_sql-0.3.1-py3-none-any.whl", hash = "sha256:13b08e238f693c1f6059f53ef06153ae5afb39cd1a36db79d1824021a6627cc2", size = 73950, upload-time = "2026-05-21T14:10:43.382Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/7a/6b62b609ce722b46638d68216159238df4d939bba83d004e626a402b1c24/confluent_sql-0.4.0-py3-none-any.whl", hash = "sha256:67c162e196c46ea96ede448b3bdc06b3caf399a0809657317ac1987e6536f3aa", size = 79572, upload-time = "2026-06-15T14:19:59.104Z" },
 ]
 
 [[package]]
@@ -308,7 +308,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "agate", specifier = "~=1.0" },
-    { name = "confluent-sql", specifier = "~=0.3.1" },
+    { name = "confluent-sql", specifier = "~=0.4.0" },
     { name = "dbt-adapters", specifier = "~=1.16" },
     { name = "dbt-common", specifier = "~=1.12" },
     { name = "dbt-core", specifier = "~=1.11" },


### PR DESCRIPTION
Upgrade to confluent-sql 0.4 and integrate 2 of the new features: global api key support and optional compute pool id