### PR TITLE
Prerelease fixes

### DIFF
--- a/MATERIALIZATIONS.md
+++ b/MATERIALIZATIONS.md
@@ -63,7 +63,7 @@ Flink only supports the `HASH` distribution strategy today, so the adapter alway
 
 When a table already exists and `--full-refresh` is not specified, the adapter performs drift detection before skipping creation. The check compares **columns**, **WITH options**, and **`distributed_by`** in a single pass and raises one error listing every violation, so you don't have to fix them one at a time.
 
-To determine the expected schema, the adapter creates a short-lived temporary table (named `__dbt_tmp_schema_check_<model>_<invocation_id>`) and issues a single `UNION ALL` query against `INFORMATION_SCHEMA.COLUMNS`, `TABLES`, and `TABLE_OPTIONS` to fetch every piece of metadata at once. For `table` and `streaming_table`, the temp table is created from the model's SELECT query; for `streaming_source`, from the model's column definitions (without the connector). The temp table is dropped immediately after the schema is read.
+To determine the expected schema, the adapter creates a short-lived temporary table (named `__dbt_tmp_schema_check_<model>`) and issues a single `UNION ALL` query against `INFORMATION_SCHEMA.COLUMNS`, `TABLES`, and `TABLE_OPTIONS` to fetch every piece of metadata at once. For `table` and `streaming_table`, the temp table is created from the model's SELECT query; for `streaming_source`, from the model's column definitions (without the connector). The temp table is dropped immediately after the schema is read. The name is deterministic per model, and the check drops any leftover temp table before creating a new one — so if an interrupted run leaks the table, the next drift check reclaims it.
 
 ### Configuration
 

--- a/MATERIALIZATIONS.md
+++ b/MATERIALIZATIONS.md
@@ -100,7 +100,7 @@ Compares the user-specified `config(distributed_by={...})` against the existing 
 **Important limitation**: As with WITH options, the adapter only verifies what the user explicitly requested. If `distributed_by` is unset, drift detection is skipped entirely, because Confluent assigns a default distribution (typically derived from the primary key) to every Kafka-backed table, and INFORMATION_SCHEMA does not distinguish user-specified from auto-assigned distribution. Note that you cannot truly *remove* a distribution: every Kafka-backed table has one. To stop the adapter from comparing against a previously-set `distributed_by`, drop the config and use `--full-refresh` to recreate the table — Confluent will then assign its default distribution.
 
 ### WITH Options Drift
-Compares existing `WITH` options against the model's `config(with={...})`. Raises an error if any configured option value has changed.
+Compares existing `WITH` options against the model's `config(with={...})`. Raises an error if any configured option value has changed. For `streaming_source`, the mandatory `config(connector='...')` is included in this comparison (it is rendered as the `connector` WITH option), so changing the connector is detected as drift.
 
 **Important limitation**: The adapter only verifies that user-specified options exist with the correct values. It does **not** detect when options are removed from the config, because connectors may add default options automatically (e.g., `fields.*.expression` from the faker connector), and we cannot distinguish between user-specified and auto-generated options.
 

--- a/changes/+drift-detect-connector-change.bugfix.md
+++ b/changes/+drift-detect-connector-change.bugfix.md
@@ -1,0 +1,1 @@
+Changing a `streaming_source` model's `connector` config is now detected as schema drift. Previously the drift check only compared the `with` config, so a connector change was silently skipped and the old connector kept running.

--- a/changes/+drift-empty-existing-guard.bugfix.md
+++ b/changes/+drift-empty-existing-guard.bugfix.md
@@ -1,0 +1,1 @@
+The schema drift check now surfaces a retriable error when INFORMATION_SCHEMA returns no columns for the *existing* table (metadata propagation lag), instead of falsely reporting every model column as added and advising a destructive `--full-refresh`. This mirrors the guard that already existed for the temp table.

--- a/changes/+drift-temp-table-leak.bugfix.md
+++ b/changes/+drift-temp-table-leak.bugfix.md
@@ -1,0 +1,1 @@
+Schema drift checks no longer permanently leak their temp table (a real Kafka-backed topic) when the run fails between creating and dropping it: the temp name is now deterministic per model (no `invocation_id` suffix) and the check drops any leftover before creating, so the next run reclaims a leak.

--- a/changes/+escape-with-option-quotes.bugfix.md
+++ b/changes/+escape-with-option-quotes.bugfix.md
@@ -1,0 +1,1 @@
+Single quotes in `with` option keys/values and in the `connector` config are now escaped (doubled) when rendered into `streaming_table`/`streaming_source` DDL, instead of breaking the statement or escaping the string literal.

--- a/dbt/adapters/confluent/impl.py
+++ b/dbt/adapters/confluent/impl.py
@@ -543,6 +543,22 @@ class ConfluentAdapter(SQLAdapter):
                 f"run with `--full-refresh` or file a bug."
             )
 
+        # Same guard, existing side: the drift check only runs when dbt's
+        # cache says the relation exists, so zero COLUMNS rows for it means
+        # the same metadata propagation lag (or the table was dropped
+        # externally mid-run). Without this guard the check would report
+        # every model column as "column added" and steer the user toward a
+        # needless --full-refresh.
+        if not existing_columns:
+            raise DbtDatabaseError(
+                f"Drift check could not introspect the existing schema for "
+                f"'{existing_relation}': the table returned no columns from "
+                f"INFORMATION_SCHEMA. This usually indicates a transient "
+                f"Confluent Cloud metadata propagation lag (or the table was "
+                f"dropped outside dbt during the run). Retry with `dbt retry`; "
+                f"if it persists, run with `--full-refresh` or file a bug."
+            )
+
         violations: list[str] = []
         violations.extend(self._check_column_drift(existing_columns, expected_columns))
         if enforce == "all":

--- a/dbt/adapters/confluent/impl.py
+++ b/dbt/adapters/confluent/impl.py
@@ -520,6 +520,7 @@ class ConfluentAdapter(SQLAdapter):
         expected_with: dict[str, str],
         expected_distribution: dict | None = None,
         enforce: Literal["all", "columns"] = "all",
+        expected_connector: str | None = None,
     ) -> None:
         """Compare existing vs expected schema and raise CompilationError on drift.
 
@@ -539,6 +540,13 @@ class ConfluentAdapter(SQLAdapter):
                         restart path under `on_schema_drift='ignore'`, where
                         options/distribution drift is fine but a column
                         mismatch would cause Flink to reject the INSERT.
+
+        `expected_connector` is streaming_source's mandatory `connector`
+        config. The materialization renders it into the DDL's WITH clause
+        (where the existing table's INFORMATION_SCHEMA options report it),
+        but it lives outside the `with` config — so it's merged into the
+        expected options here to participate in options drift like any
+        other option. None for materializations without a connector.
         """
         existing_columns, expected_columns, existing_options, existing_distribution = (
             self._partition_drift_catalog(
@@ -582,7 +590,10 @@ class ConfluentAdapter(SQLAdapter):
         violations: list[str] = []
         violations.extend(self._check_column_drift(existing_columns, expected_columns))
         if enforce == "all":
-            violations.extend(self._check_options_drift(expected_with, existing_options))
+            expected_options = dict(expected_with)
+            if expected_connector is not None:
+                expected_options["connector"] = expected_connector
+            violations.extend(self._check_options_drift(expected_options, existing_options))
             violations.extend(
                 self._check_distribution_drift(expected_distribution, existing_distribution)
             )

--- a/dbt/adapters/confluent/impl.py
+++ b/dbt/adapters/confluent/impl.py
@@ -442,6 +442,17 @@ class ConfluentAdapter(SQLAdapter):
         return "__dbt_tmp_schema_check_" + identifier + "_" + invocation_id.replace("-", "")
 
     @available
+    def escape_string_literal(self, value: object) -> str:
+        """Escape a value for embedding in a Flink SQL string literal ('...').
+
+        Flink SQL escapes a single quote inside a string literal by doubling
+        it. Used when rendering user-supplied config (WITH option keys/values,
+        `connector`) into DDL, where an unescaped quote would break the
+        statement — or terminate the literal and inject arbitrary clauses.
+        """
+        return str(value).replace("'", "''")
+
+    @available
     def validate_distributed_by_config(self, dist: object) -> None:
         """Raise CompilationError if the `distributed_by` config is malformed.
 

--- a/dbt/adapters/confluent/impl.py
+++ b/dbt/adapters/confluent/impl.py
@@ -437,9 +437,18 @@ class ConfluentAdapter(SQLAdapter):
         return {"ctes": ctes, "main_sql": main_sql}
 
     @available
-    def generate_schema_check_temp_name(self, identifier: str, invocation_id: str) -> str:
-        """Generate a unique temporary table name for schema drift checks."""
-        return "__dbt_tmp_schema_check_" + identifier + "_" + invocation_id.replace("-", "")
+    def generate_schema_check_temp_name(self, identifier: str) -> str:
+        """Generate the temporary table name for a model's schema drift check.
+
+        Deterministic per model, on purpose: Jinja has no try/finally, so a
+        run that dies between creating and dropping the temp table leaks it
+        as a real Kafka-backed topic. With a stable name, the next drift
+        check reclaims the leak via its DROP TABLE IF EXISTS before
+        recreating. (Concurrent runs of the same project would collide on
+        this name, but they already collide on the deterministic Flink
+        statement names, so this adds no new hazard.)
+        """
+        return "__dbt_tmp_schema_check_" + identifier
 
     @available
     def escape_string_literal(self, value: object) -> str:

--- a/dbt/include/confluent/macros/materializations/models/helpers.sql
+++ b/dbt/include/confluent/macros/materializations/models/helpers.sql
@@ -202,13 +202,17 @@
     DROP TABLE IF EXISTS {{ temp_relation }}
   {% endcall %}
 
+  {# `connector` (streaming_source) is rendered into the DDL's WITH clause
+     but configured outside `with` — pass it along so a connector change is
+     caught as options drift. None for the other materializations. #}
   {% do adapter.check_schema_drift(
     existing_relation,
     temp_relation,
     load_result('get_drift_catalog').table,
     config.get('with', {}),
     config.get('distributed_by'),
-    enforce
+    enforce,
+    config.get('connector')
   ) %}
 {% endmacro %}
 

--- a/dbt/include/confluent/macros/materializations/models/helpers.sql
+++ b/dbt/include/confluent/macros/materializations/models/helpers.sql
@@ -167,13 +167,20 @@
               restart path under on_schema_drift='ignore' to keep restart
               safe without rejecting benign options/distribution drift. #}
 
-  {% set temp_table_name = adapter.generate_schema_check_temp_name(this.identifier, invocation_id) %}
+  {% set temp_table_name = adapter.generate_schema_check_temp_name(this.identifier) %}
   {% set temp_relation = adapter.Relation.create(
     database=this.database,
     schema=this.schema,
     identifier=temp_table_name,
     type='table'
   ) %}
+
+  {# Jinja has no try/finally, so a run that died between creating and
+     dropping this temp table leaked it. The name is deterministic per
+     model, so reclaim any leftover before creating. #}
+  {% call statement('drop_leaked_temp_table', hidden=True) %}
+    DROP TABLE IF EXISTS {{ temp_relation }}
+  {% endcall %}
 
   {% if has_select_query %}
     {% call statement('create_temp_table', hidden=True) %}

--- a/dbt/include/confluent/macros/materializations/models/streaming_source.sql
+++ b/dbt/include/confluent/macros/materializations/models/streaming_source.sql
@@ -40,9 +40,9 @@
     ( {{ sql }})
     {{ get_distributed_by_clause() }}
     WITH (
-      'connector' = '{{ connector }}'
+      'connector' = '{{ adapter.escape_string_literal(connector) }}'
       {%- for key, value in with_options.items() -%}
-      , '{{ key }}' = '{{ value }}'
+      , '{{ adapter.escape_string_literal(key) }}' = '{{ adapter.escape_string_literal(value) }}'
       {%- endfor -%}
     )
   {%- endcall %}

--- a/dbt/include/confluent/macros/materializations/models/streaming_table.sql
+++ b/dbt/include/confluent/macros/materializations/models/streaming_table.sql
@@ -41,7 +41,7 @@
       {% if with_options %}
       WITH (
         {%- for key, value in with_options.items() -%}
-        '{{ key }}' = '{{ value }}'{%- if not loop.last %},{%- endif %}
+        '{{ adapter.escape_string_literal(key) }}' = '{{ adapter.escape_string_literal(value) }}'{%- if not loop.last %},{%- endif %}
         {%- endfor -%}
       )
       {% endif %}

--- a/tests/unit/test_check_schema_drift.py
+++ b/tests/unit/test_check_schema_drift.py
@@ -536,6 +536,77 @@ class TestCheckSchemaDriftOrchestrator:
         assert "column" not in violation_section.lower()
         assert "distribution" not in violation_section.lower()
 
+    def test_connector_change_detected(self):
+        """streaming_source's `connector` config is rendered into the DDL's
+        WITH clause but lives outside the `with` config — the orchestrator
+        must merge it into the expected options so changing it is caught."""
+        catalog = _make_catalog(
+            [
+                _row(
+                    section="COLUMNS",
+                    table_name=self.EXISTING_ID,
+                    col_name="id",
+                    data_type="BIGINT",
+                ),
+                _row(
+                    section="COLUMNS",
+                    table_name=self.TEMP_ID,
+                    col_name="id",
+                    data_type="BIGINT",
+                ),
+                _row(
+                    section="TABLE_OPTIONS",
+                    table_name=self.EXISTING_ID,
+                    option_key="connector",
+                    option_value="faker",
+                ),
+            ]
+        )
+        adapter = ConfluentAdapter.__new__(ConfluentAdapter)
+        with pytest.raises(CompilationError) as excinfo:
+            adapter.check_schema_drift(
+                _relation(self.EXISTING_ID),
+                _relation(self.TEMP_ID),
+                catalog,
+                expected_with={},
+                expected_connector="datagen",
+            )
+        msg = str(excinfo.value)
+        assert "option: 'connector' existing='faker', expected='datagen'" in msg
+
+    def test_matching_connector_passes(self):
+        """A connector that matches the existing table's option is no drift."""
+        catalog = _make_catalog(
+            [
+                _row(
+                    section="COLUMNS",
+                    table_name=self.EXISTING_ID,
+                    col_name="id",
+                    data_type="BIGINT",
+                ),
+                _row(
+                    section="COLUMNS",
+                    table_name=self.TEMP_ID,
+                    col_name="id",
+                    data_type="BIGINT",
+                ),
+                _row(
+                    section="TABLE_OPTIONS",
+                    table_name=self.EXISTING_ID,
+                    option_key="connector",
+                    option_value="faker",
+                ),
+            ]
+        )
+        adapter = ConfluentAdapter.__new__(ConfluentAdapter)
+        adapter.check_schema_drift(
+            _relation(self.EXISTING_ID),
+            _relation(self.TEMP_ID),
+            catalog,
+            expected_with={},
+            expected_connector="faker",
+        )
+
     def test_no_drift_returns_silently(self):
         """When nothing has drifted the orchestrator returns without raising."""
         catalog = _make_catalog(

--- a/tests/unit/test_check_schema_drift.py
+++ b/tests/unit/test_check_schema_drift.py
@@ -643,6 +643,45 @@ class TestCheckSchemaDriftOrchestrator:
         # Must not look like a regular column-list drift error.
         assert "drift detected" not in msg.lower()
 
+    def test_empty_existing_columns_raises_distinct_error(self):
+        """An empty existing_columns must NOT masquerade as a column-list drift.
+
+        The drift check only runs when dbt's cache says the relation exists,
+        so the existing table coming back with zero COLUMNS rows is the same
+        metadata propagation lag as the temp-table case (or an external drop
+        mid-run) — not "every column was added". It must surface as a
+        retriable DbtDatabaseError, not a CompilationError advising a
+        destructive --full-refresh.
+        """
+        catalog = _make_catalog(
+            [
+                _row(
+                    section="COLUMNS",
+                    table_name=self.TEMP_ID,
+                    col_name="id",
+                    data_type="BIGINT",
+                ),
+                _row(
+                    section="COLUMNS",
+                    table_name=self.TEMP_ID,
+                    col_name="value",
+                    data_type="STRING",
+                ),
+            ]
+        )
+        adapter = ConfluentAdapter.__new__(ConfluentAdapter)
+        with pytest.raises(DbtDatabaseError) as excinfo:
+            adapter.check_schema_drift(
+                _relation(self.EXISTING_ID),
+                _relation(self.TEMP_ID),
+                catalog,
+                expected_with={},
+            )
+        msg = str(excinfo.value)
+        assert "INFORMATION_SCHEMA" in msg
+        # Must not look like a regular column-list drift error.
+        assert "drift detected" not in msg.lower()
+
     def test_enforce_columns_ignores_options_and_distribution_drift(self):
         """With enforce='columns', only column violations should raise."""
         catalog = _make_catalog(

--- a/tests/unit/test_escape_string_literal.py
+++ b/tests/unit/test_escape_string_literal.py
@@ -1,0 +1,45 @@
+"""Unit tests for `ConfluentAdapter.escape_string_literal`.
+
+The streaming materializations embed user config (`with` option keys/values,
+`connector`) inside single-quoted string literals in generated DDL. Flink SQL
+escapes a quote inside a literal by doubling it; anything less lets a value
+like a faker expression containing `'` break the statement — or terminate the
+literal and inject clauses into the DDL.
+"""
+
+import pytest
+
+from dbt.adapters.confluent.impl import ConfluentAdapter
+
+
+@pytest.fixture
+def adapter():
+    return ConfluentAdapter.__new__(ConfluentAdapter)
+
+
+def test_plain_string_unchanged(adapter):
+    assert adapter.escape_string_literal("append") == "append"
+
+
+def test_single_quote_doubled(adapter):
+    assert adapter.escape_string_literal("it's") == "it''s"
+
+
+def test_multiple_quotes_all_doubled(adapter):
+    assert adapter.escape_string_literal("a'b'c") == "a''b''c"
+
+
+def test_already_doubled_quotes_doubled_again(adapter):
+    # A pre-doubled value must not be "recognized" as escaped: config holds
+    # raw values, so each raw quote is doubled independently.
+    assert adapter.escape_string_literal("''") == "''''"
+
+
+def test_injection_attempt_stays_inside_literal(adapter):
+    value = "x') WITH ('connector' = 'evil"
+    assert adapter.escape_string_literal(value) == "x'') WITH (''connector'' = ''evil"
+
+
+def test_non_string_values_are_stringified(adapter):
+    assert adapter.escape_string_literal(10) == "10"
+    assert adapter.escape_string_literal(1.5) == "1.5"


### PR DESCRIPTION
4 small fixes that came up after a review of the whole main branch since v0.2.1. Each commit is a separate fix, but I feel they are small enough to fit in a single PR.
As pointed in the towncrier fragments, the changes are:
- Changing a `streaming_source` model's `connector` config is now detected as schema drift. Previously the drift check only compared the `with` config, so a connector change was silently skipped and the old connector kept running.
- The schema drift check now surfaces a retriable error when INFORMATION_SCHEMA returns no columns for the *existing* table (metadata propagation lag), instead of falsely reporting every model column as added and advising a destructive `--full-refresh`. This mirrors the guard that already existed for the temp table.
- Single quotes in `with` option keys/values and in the `connector` config are now escaped (doubled) when rendered into `streaming_table`/`streaming_source` DDL, instead of breaking the statement or escaping the string literal.
- Schema drift checks no longer permanently leak their temp table (a real Kafka-backed topic) when the run fails between creating and dropping it: the temp name is now deterministic per model (no `invocation_id` suffix) and the check drops any leftover before creating, so the next run reclaims a leak.

Fixing this last point also gave me an idea for a better solution overall, which is using dbt's hooks. If that works, I'll open a separate PR for it