### PR TITLE
Fix `table` materialization to submit CTAS in snapshot mode

### DIFF
--- a/changes/77.bugfix.md
+++ b/changes/77.bugfix.md
@@ -1,0 +1,1 @@
+The `table` materialization's CTAS statement is now submitted in `snapshot_ddl` mode. Previously it used no explicit execution mode, so it fell back to the connection default (`streaming_query`), contradicting the documented snapshot behavior and leaving an unbounded statement running instead of one that completes.

--- a/dbt/include/confluent/macros/materializations/models/table.sql
+++ b/dbt/include/confluent/macros/materializations/models/table.sql
@@ -16,7 +16,8 @@
   {{ run_hooks(pre_hooks, inside_transaction=True) }}
 
   -- build model
-  {% call statement('main', statement_name=get_statement_name()) -%}
+  {% call statement('main', execution_mode="snapshot_ddl",
+                    statement_name=get_statement_name()) -%}
     {{ get_create_table_as_sql(False, target_relation, sql) }}
   {%- endcall %}
 

--- a/tests/functional/adapter/test_table.py
+++ b/tests/functional/adapter/test_table.py
@@ -1,0 +1,52 @@
+"""Tests for the `table` materialization."""
+
+import pytest
+
+from dbt.tests.util import run_dbt
+from tests.functional.adapter._helpers import get_result_by_name
+from tests.functional.adapter.fixtures import ConfluentFixtures
+
+SIMPLE_TABLE = """
+{{ config(materialized='table') }}
+select 1 as id, 'a' as name
+"""
+
+SIMPLE_TABLE_MODELS_YML = """
+models:
+  - name: simple_table
+    columns:
+      - name: id
+        data_type: int
+      - name: name
+        data_type: string
+"""
+
+
+class TestTableMaterialization(ConfluentFixtures):
+    NAME = "table_basic"
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "simple_table.sql": SIMPLE_TABLE,
+            "models.yml": SIMPLE_TABLE_MODELS_YML,
+        }
+
+    @pytest.fixture(scope="class", autouse=True)
+    def setup_and_teardown(self, project):
+        yield
+        project.run_sql("drop table if exists simple_table")
+
+    def test_ctas_completes_in_snapshot_mode(self, project):
+        """Regression for #77: the CTAS statement must run in snapshot mode,
+        not streaming. A streaming-mode CTAS never reaches a terminal phase
+        on its own; get_response() reports the statement's terminal phase as
+        the result message, so this is checked directly from the run result
+        rather than a post-run statement lookup (which would race the
+        adapter's own post-execute cleanup of completed statements)."""
+        results = run_dbt(["run"])
+        result = get_result_by_name(results, "simple_table")
+        assert result.message == "Phase.COMPLETED", (
+            "simple_table's CTAS did not complete on its own "
+            f"(message: {result.message}) -- likely submitted as a streaming query"
+        )

--- a/tests/functional/adapter/test_table.py
+++ b/tests/functional/adapter/test_table.py
@@ -46,6 +46,7 @@ class TestTableMaterialization(ConfluentFixtures):
         adapter's own post-execute cleanup of completed statements)."""
         results = run_dbt(["run"])
         result = get_result_by_name(results, "simple_table")
+        assert result is not None, "simple_table not found in run results"
         assert result.message == "Phase.COMPLETED", (
             "simple_table's CTAS did not complete on its own "
             f"(message: {result.message}) -- likely submitted as a streaming query"


### PR DESCRIPTION
Fixes #77

Fix confirmed working — all 9 functional schema-drift tests pass against live Confluent Cloud, and the logs now show the "Snapshot queries... Early Access" warning that only fires on the snapshot code path, proving table now actually submits in snapshot mode (previously it silently defaulted to streaming_query).

Root cause:
dbt/include/confluent/macros/materializations/models/table.sql called the CTAS statement() macro without an execution_mode, so it fell through to the connection-level default (STREAMING_QUERY in connections.py:74) — contradicting the documented/intended snapshot behavior for table.

Fix: pass execution_mode="snapshot_ddl" explicitly (the CTAS is a DDL statement with an embedded query, matching streaming_table's DDL/INSERT split pattern, just in snapshot form).